### PR TITLE
added missing include (on Arch Linux) needed for uninitialized_copy_n()

### DIFF
--- a/bstone_memory_binary_reader.cpp
+++ b/bstone_memory_binary_reader.cpp
@@ -29,7 +29,7 @@ Free Software Foundation, Inc.,
 
 #include "bstone_memory_binary_reader.h"
 #include "bstone_endian.h"
-
+#include <memory>
 
 namespace bstone {
 


### PR DESCRIPTION
Hi Boris, 

this change is need for compilation with gcc-6.1.1 on Arch Linux.