### PR TITLE
Add "quit on escape" option

### DIFF
--- a/src/3d_def.h
+++ b/src/3d_def.h
@@ -4330,6 +4330,8 @@ extern bool g_always_run;
 extern bool g_heart_beat_sound;
 extern bool g_rotated_automap;
 
+extern bool g_quit_on_escape;
+
 
 class ArchiveException : public std::exception {
 public:

--- a/src/3d_main.cpp
+++ b/src/3d_main.cpp
@@ -170,6 +170,9 @@ bool g_heart_beat_sound = default_heart_beat_sound;
 static const bool default_rotated_automap = false;
 bool g_rotated_automap = default_rotated_automap;
 
+static const bool default_quit_on_escape = true;
+bool g_quit_on_escape = default_quit_on_escape;
+
 GameType g_game_type;
 
 
@@ -6704,6 +6707,7 @@ const auto gp_flags_name = "gp_flags";
 const auto gp_no_wall_hit_sfx_name = "gp_no_wall_hit_sfx";
 const auto gp_is_always_run_name = "gp_is_always_run";
 const auto gp_use_heart_beat_sfx_name = "gp_use_heart_beat_sfx";
+const auto gp_quit_on_escape_name = "gp_quit_on_escape";
 const auto am_is_rotated_name = "am_is_rotated";
 
 
@@ -6940,6 +6944,8 @@ void set_config_defaults()
 
     ::g_heart_beat_sound = ::default_heart_beat_sound;
     ::g_rotated_automap = ::default_rotated_automap;
+
+    ::g_quit_on_escape = ::default_quit_on_escape;
 
     ::vid_widescreen = ::default_vid_widescreen;
 }
@@ -7255,6 +7261,15 @@ void read_text_config()
                             ::g_heart_beat_sound = (value != 0);
                         }
                     }
+                    else if (name == gp_quit_on_escape_name)
+                    {
+                        auto value = int{};
+
+                        if (bstone::StringHelper::lexical_cast(value_string, value))
+                        {
+                            ::g_quit_on_escape = (value != 0);
+                        }
+                    }
                     else if (name == am_is_rotated_name)
                     {
                         auto value = int{};
@@ -7471,6 +7486,7 @@ void write_text_config()
     write_config_entry(writer, gp_no_wall_hit_sfx_name, ::g_no_wall_hit_sound);
     write_config_entry(writer, gp_is_always_run_name, ::g_always_run);
     write_config_entry(writer, gp_use_heart_beat_sfx_name, ::g_heart_beat_sound);
+    write_config_entry(writer, gp_quit_on_escape_name, ::g_quit_on_escape);
 
     writer.write("\n// Auto-map\n");
     write_config_entry(writer, am_is_rotated_name, ::g_rotated_automap);

--- a/src/3d_main.cpp
+++ b/src/3d_main.cpp
@@ -170,7 +170,7 @@ bool g_heart_beat_sound = default_heart_beat_sound;
 static const bool default_rotated_automap = false;
 bool g_rotated_automap = default_rotated_automap;
 
-static const bool default_quit_on_escape = true;
+static const bool default_quit_on_escape = false;
 bool g_quit_on_escape = default_quit_on_escape;
 
 GameType g_game_type;

--- a/src/3d_menu.cpp
+++ b/src/3d_menu.cpp
@@ -1358,6 +1358,15 @@ void US_ControlPanel(
             break;
 
         case -1:
+            // on hit ESC on main menu
+            if (ingame && !g_quit_on_escape) {
+                // return to game if quit on escape not enabled
+                StartGame = 1;
+            } else {
+                CP_Quit();
+            }
+            break;
+
         case MM_LOGOFF:
             CP_Quit();
             break;

--- a/src/3d_menu.cpp
+++ b/src/3d_menu.cpp
@@ -222,10 +222,9 @@ CP_itemtype SwitchMenu[] = {
     { AT_ENABLED, "NO WALL HIT SOUND", 0 },
     { AT_ENABLED, "MODERN CONTROLS", 0 },
     { AT_ENABLED, "ALWAYS RUN", 0 },
+    { AT_ENABLED, "QUIT ON ESCAPE", 0 },
     { AT_ENABLED, "HEART BEAT SOUND", 0 },
     { AT_ENABLED, "ROTATED AUTOMAP", 0 },
-
-    { AT_ENABLED, "QUIT ON ESCAPE", 0 },
 };
 
 
@@ -1952,6 +1951,12 @@ void CP_Switches(
             DrawSwitchMenu();
             break;
 
+        case SW_QUIT_ON_ESCAPE:
+            g_quit_on_escape = !g_quit_on_escape;
+            ShootSnd();
+            DrawSwitchMenu();
+            break;
+
         case SW_HEART_BEAT_SOUND:
             g_heart_beat_sound = !g_heart_beat_sound;
             ShootSnd();
@@ -1960,12 +1965,6 @@ void CP_Switches(
 
         case SW_ROTATED_AUTOMAP:
             g_rotated_automap = !g_rotated_automap;
-            ShootSnd();
-            DrawSwitchMenu();
-            break;
-
-        case SW_QUIT_ON_ESCAPE:
-            g_quit_on_escape = !g_quit_on_escape;
             ShootSnd();
             DrawSwitchMenu();
             break;
@@ -2055,6 +2054,12 @@ void DrawAllSwitchLights(
                 }
                 break;
 
+            case SW_QUIT_ON_ESCAPE:
+                if (g_quit_on_escape) {
+                    ++Shape;
+                }
+                break;
+
             case SW_HEART_BEAT_SOUND:
                 if (g_heart_beat_sound) {
                     ++Shape;
@@ -2063,12 +2068,6 @@ void DrawAllSwitchLights(
 
             case SW_ROTATED_AUTOMAP:
                 if (g_rotated_automap) {
-                    ++Shape;
-                }
-                break;
-
-            case SW_QUIT_ON_ESCAPE:
-                if (g_quit_on_escape) {
                     ++Shape;
                 }
                 break;
@@ -2095,10 +2094,10 @@ void DrawSwitchDescription(
         "TOGGLES WALL HIT SOUND",
         "TOGGLES BETWEEN CLASSIC AND MODERN CONTROLS",
         "TOGGLES ALWAYS RUN MODE",
+        "ESC QUITS INSTEAD OF RETURNING TO GAME",
         "TOGGLES HEART BEAT SOUND WITH EKG",
         "TOGGLES <TAB>/<SHIFT+TAB> FUNCTIONS",
 
-        "ESC QUITS INSTEAD OF RETURNING TO GAME",
     };
 
     fontnumber = 2;
@@ -3607,8 +3606,8 @@ void DrawOutline(
 void SetupControlPanel()
 {
     // BBi
-    SwitchItems.amount = (::is_ps() ? 7 : 9);
-    SwitchItems.y = MENU_Y + (::is_ps() ? 15 : 7);
+    SwitchItems.amount = (::is_ps() ? 8 : 10);
+    SwitchItems.y = MENU_Y + (::is_ps() ? 11 : 3);
     // BBi
 
     ControlPanelAlloc();

--- a/src/3d_menu.cpp
+++ b/src/3d_menu.cpp
@@ -224,6 +224,8 @@ CP_itemtype SwitchMenu[] = {
     { AT_ENABLED, "ALWAYS RUN", 0 },
     { AT_ENABLED, "HEART BEAT SOUND", 0 },
     { AT_ENABLED, "ROTATED AUTOMAP", 0 },
+
+    { AT_ENABLED, "QUIT ON ESCAPE", 0 },
 };
 
 
@@ -1961,6 +1963,12 @@ void CP_Switches(
             ShootSnd();
             DrawSwitchMenu();
             break;
+
+        case SW_QUIT_ON_ESCAPE:
+            g_quit_on_escape = !g_quit_on_escape;
+            ShootSnd();
+            DrawSwitchMenu();
+            break;
         }
     } while (which >= 0);
 
@@ -2058,6 +2066,12 @@ void DrawAllSwitchLights(
                     ++Shape;
                 }
                 break;
+
+            case SW_QUIT_ON_ESCAPE:
+                if (g_quit_on_escape) {
+                    ++Shape;
+                }
+                break;
             }
 
             VWB_DrawPic(SwitchItems.x - 16, SwitchItems.y + i * SwitchItems.y_spacing - 1, Shape);
@@ -2083,6 +2097,8 @@ void DrawSwitchDescription(
         "TOGGLES ALWAYS RUN MODE",
         "TOGGLES HEART BEAT SOUND WITH EKG",
         "TOGGLES <TAB>/<SHIFT+TAB> FUNCTIONS",
+
+        "ESC QUITS INSTEAD OF RETURNING TO GAME",
     };
 
     fontnumber = 2;

--- a/src/3d_menu.h
+++ b/src/3d_menu.h
@@ -144,10 +144,10 @@ enum sw_labels {
     SW_NO_WALL_HIT_SOUND,
     SW_MODERN_CONTROLS,
     SW_ALWAYS_RUN,
+    SW_QUIT_ON_ESCAPE,
     SW_HEART_BEAT_SOUND,
     SW_ROTATED_AUTOMAP,
 
-    SW_QUIT_ON_ESCAPE,
 }; // sw_labels
 
 // BBi

--- a/src/3d_menu.h
+++ b/src/3d_menu.h
@@ -146,6 +146,8 @@ enum sw_labels {
     SW_ALWAYS_RUN,
     SW_HEART_BEAT_SOUND,
     SW_ROTATED_AUTOMAP,
+
+    SW_QUIT_ON_ESCAPE,
 }; // sw_labels
 
 // BBi


### PR DESCRIPTION
This is a minor change but it fixes something that drives me nuts.  Normally if you are in game you press the "ESC" key to go into the options menu or to pause the game.  However you can't press "ESC" again to go back into the game;  instead you are prompted to "Quit to DOS".  Some sourceports, such as the Wolfenstein 3D sourceport ecwolf, add an option so that pressing ESC in the main menu returns to your game that is in progress instead of prompting an exit. 

This change will add a "Quit on escape" option under the "Switches" menu.  Turning this option off will change the game's behavior to the one described above.  This option defaults to on to mimic the game's original behavior.