### PR TITLE
Eliminate a gap between weapons sprite and the top of status bar

### DIFF
--- a/src/3d_scale.cpp
+++ b/src/3d_scale.cpp
@@ -197,9 +197,9 @@ void generic_scale_shape(
         y1 = ::vga_3d_view_top;
     }
 
-    if (y2 >= ::vga_3d_view_bottom)
+    if (y2 > ::vga_3d_view_bottom)
     {
-        y2 = ::vga_3d_view_bottom - 1;
+        y2 = ::vga_3d_view_bottom;
     }
 
     if (y2 <= y1)


### PR DESCRIPTION
See #87 for details.