### PR TITLE
Fix for black bar dividers not being cleared.

### DIFF
--- a/src/id_vl.cpp
+++ b/src/id_vl.cpp
@@ -1931,9 +1931,9 @@ void vid_set_ui_mask_3d(
 {
     ::vid_set_ui_mask(
         0,
-        ::ref_3d_view_top_y - 1,
+        ::ref_3d_view_top_y - ::ref_3d_margin,
         ::vga_ref_width,
-        ::ref_3d_view_height + 1,
+        ::ref_3d_view_height + 2 * ::ref_3d_margin,
         value);
 }
 


### PR DESCRIPTION
When going from in-game, to menu, then back in-game, the region above and below the main viewport does not get cleared, leaving the remnants of the menu. Also avoids drawing over the HUD in case ref_3d_margin is set to 0.