### PR TITLE
Avoid a segfault at level load

### DIFF
--- a/src/jm_tp.cpp
+++ b/src/jm_tp.cpp
@@ -3360,7 +3360,7 @@ void TP_FreeScript(
 
     if (id_cache) {
         UNCACHEGRCHUNK(id_cache);
-    } else if ((p_i->script) && (p_i->flags & TPF_CACHED_SCRIPT)) {
+    } else if ((*p_i->script != NULL) && (p_i->flags & TPF_CACHED_SCRIPT)) {
         delete [] static_cast<char*>(p_i->scriptstart);
         p_i->scriptstart = nullptr;
     }


### PR DESCRIPTION
When building BStone with clang (on OpenBSD), the follow warning appears:
```
[6/65] /usr/ports/pobj/bstone-1.1.9.1/bin/c++   -I/usr/ports/pobj/bstone-1.1.9.1/bstone-48c286fb1012f6faa9dbf4b0f237e2b19ce01ac5/src/dosbox -I/usr/local/include/SDL2 -O2 -pipe -DNDEBUG   -std=c++11 -MD -MT CMakeFiles/bstone.dir/jm_tp.cpp.o -MF CMakeFiles/bstone.dir/jm_tp.cpp.o.d -o CMakeFiles/bstone.dir/jm_tp.cpp.o -c /usr/ports/pobj/bstone-1.1.9.1/bstone-48c286fb1012f6faa9dbf4b0f237e2b19ce01ac5/src/jm_tp.cpp
/usr/ports/pobj/bstone-1.1.9.1/bstone-48c286fb1012f6faa9dbf4b0f237e2b19ce01ac5/src/jm_tp.cpp:3363:22: warning: address of array 'p_i->script' will always evaluate to 'true' [-Wpointer-bool-conversion]
    } else if ((p_i->script) && (p_i->flags & TPF_CACHED_SCRIPT)) {
                ~~~~~^~~~~~  ~~
1 warning generated.
```
This causes the game to segfault upon trying to load a level.

This PR makes the warning go away, allows levels to load properly, and I believe is the actual intention of this code.
I'm using this in the OpenBSD package of BStone.

Thanks!