### PR TITLE
Remove dependency on TestBigEndian

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,14 +19,6 @@ find_package(SDL2W 2.0.4 REQUIRED COMPONENTS ${BSTONE_SDL2_COMPONENTS})
 
 
 #
-# Byte order.
-#
-include(TestBigEndian)
-unset(BSTONE_USE_BIG_ENDIAN)
-TEST_BIG_ENDIAN(BSTONE_USE_BIG_ENDIAN)
-
-
-#
 # Target.
 #
 add_executable(${PROJECT_NAME} "")
@@ -55,14 +47,6 @@ endif ()
 #
 # Target compile definitions.
 #
-if (BSTONE_USE_BIG_ENDIAN)
-	target_compile_definitions(
-		${PROJECT_NAME}
-		PRIVATE
-			BSTONE_USE_BIG_ENDIAN
-	)
-endif ()
-
 if (BSTONE_USE_PCH)
 	target_compile_definitions(
 		${PROJECT_NAME}

--- a/src/bstone_endian.h
+++ b/src/bstone_endian.h
@@ -32,6 +32,7 @@ Free Software Foundation, Inc.,
 
 
 #include <cstdint>
+#include "SDL_endian.h"
 
 
 namespace bstone
@@ -44,11 +45,11 @@ enum class EndianId
 	big,
 	little,
 
-#ifdef BSTONE_USE_BIG_ENDIAN
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
 	native = big,
-#else
+#else // SDL_BYTEORDER == SDL_BIG_ENDIAN
 	native = little,
-#endif // BSTONE_USE_BIG_ENDIAN
+#endif // SDL_BYTEORDER == SDL_BIG_ENDIAN
 }; // EndianId
 
 


### PR DESCRIPTION
TestBigEndian makes CMake to fail (see #132).