### PR TITLE
Fix compile errors for VS2019

### DIFF
--- a/src/3d_def.h
+++ b/src/3d_def.h
@@ -27,6 +27,7 @@ Free Software Foundation, Inc.,
 
 
 #include <functional>
+#include <string>
 #include <vector>
 #include "movie.h"
 

--- a/src/bstone_memory_stream.cpp
+++ b/src/bstone_memory_stream.cpp
@@ -24,6 +24,7 @@ Free Software Foundation, Inc.,
 
 #include "bstone_memory_stream.h"
 #include <algorithm>
+#include <memory>
 
 
 namespace bstone


### PR DESCRIPTION
Add missing standard headers to fix compiling errors in VS2019.

See #153 for details.