### PR TITLE
Fix bonuses not getting applied correctly if...

### DIFF
--- a/src/3d_agent.cpp
+++ b/src/3d_agent.cpp
@@ -4640,7 +4640,7 @@ void CheckPinballBonus(
 
 	// Check TOTAL ENEMY bonus
 	//
-	if (gamestuff.level[gamestate.mapon].stats.total_enemy ==
+	if (gamestuff.level[gamestate.mapon].stats.total_enemy <=
 		gamestuff.level[gamestate.mapon].stats.accum_enemy)
 	{
 		ActivatePinballBonus(B_ENEMY_DESTROYED);
@@ -4648,7 +4648,7 @@ void CheckPinballBonus(
 
 	// Check TOTAL POINTS bonus
 	//
-	if (gamestuff.level[gamestate.mapon].stats.total_points ==
+	if (gamestuff.level[gamestate.mapon].stats.total_points <=
 		gamestuff.level[gamestate.mapon].stats.accum_points)
 	{
 		ActivatePinballBonus(B_TOTAL_POINTS);
@@ -4656,7 +4656,7 @@ void CheckPinballBonus(
 
 	// Check INFORMANTS ALIVE bonus
 	//
-	if ((gamestuff.level[gamestate.mapon].stats.total_inf ==
+	if ((gamestuff.level[gamestate.mapon].stats.total_inf <=
 		gamestuff.level[gamestate.mapon].stats.accum_inf) && // All informants alive?
 		(gamestuff.level[gamestate.mapon].stats.total_inf) && // Any informants in level?
 		((BONUS_SHOWN & (B_TOTAL_POINTS | B_ENEMY_DESTROYED)) ==

--- a/src/3d_agent.cpp
+++ b/src/3d_agent.cpp
@@ -4640,7 +4640,7 @@ void CheckPinballBonus(
 
 	// Check TOTAL ENEMY bonus
 	//
-	if (gamestuff.level[gamestate.mapon].stats.total_enemy <=
+	if (gamestuff.level[gamestate.mapon].stats.total_enemy <= // FIXME: https://github.com/bibendovsky/bstone/issues/86 https://github.com/bibendovsky/bstone/pull/176
 		gamestuff.level[gamestate.mapon].stats.accum_enemy)
 	{
 		ActivatePinballBonus(B_ENEMY_DESTROYED);
@@ -4648,7 +4648,7 @@ void CheckPinballBonus(
 
 	// Check TOTAL POINTS bonus
 	//
-	if (gamestuff.level[gamestate.mapon].stats.total_points <=
+	if (gamestuff.level[gamestate.mapon].stats.total_points <= // FIXME: https://github.com/bibendovsky/bstone/issues/86 https://github.com/bibendovsky/bstone/pull/176
 		gamestuff.level[gamestate.mapon].stats.accum_points)
 	{
 		ActivatePinballBonus(B_TOTAL_POINTS);
@@ -4656,7 +4656,7 @@ void CheckPinballBonus(
 
 	// Check INFORMANTS ALIVE bonus
 	//
-	if ((gamestuff.level[gamestate.mapon].stats.total_inf <=
+	if ((gamestuff.level[gamestate.mapon].stats.total_inf <= // FIXME: https://github.com/bibendovsky/bstone/issues/86 https://github.com/bibendovsky/bstone/pull/176
 		gamestuff.level[gamestate.mapon].stats.accum_inf) && // All informants alive?
 		(gamestuff.level[gamestate.mapon].stats.total_inf) && // Any informants in level?
 		((BONUS_SHOWN & (B_TOTAL_POINTS | B_ENEMY_DESTROYED)) ==


### PR DESCRIPTION
the "Enemy Destroyed", "Total Points" or "Informants Alive" percentage goes beyond 100%.
This is a workaround to get all bonuses in case of a miscount (https://github.com/bibendovsky/bstone/issues/86)