### PR TITLE
Set to null `sd_mixer_` in `sd_shutdown`

### DIFF
--- a/src/id_sd.cpp
+++ b/src/id_sd.cpp
@@ -345,6 +345,7 @@ void sd_shutdown()
 	if (sd_mixer_)
 	{
 		sd_mixer_->uninitialize();
+		sd_mixer_ = nullptr;
 	}
 
 	audio_content_mgr = nullptr;


### PR DESCRIPTION
Switching between audio drivers in menu causes a crash (#386).