### PR TITLE
[SDL] Fix error "Renderer already associated with window"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - Cancel strafe movement if both keys are pressed.
 - [SDL] Reduce CPU usage for digitized low-pass filtering.
+- [SDL] Error "Renderer already associated with window".
 - Option `vid_renderer` now works in command-line.
 - [OAL] Load AL symbols within context.
 - [OAL] List only available extensions.

--- a/src/bstone_sw_video.cpp
+++ b/src/bstone_sw_video.cpp
@@ -42,7 +42,6 @@ Free Software Foundation, Inc.,
 #include "bstone_logger.h"
 #include "bstone_sdl_exception.h"
 #include "bstone_sdl_texture_lock.h"
-#include "bstone_sdl_utils.h"
 #include "bstone_video.h"
 
 #include "bstone_detail_ren_3d_utils.h"
@@ -1160,8 +1159,6 @@ try
 		vid_layout_.window_height,
 		window_flags
 	))};
-
-	bstone::sdl::fill_window_black(window_.get());
 }
 catch (...)
 {


### PR DESCRIPTION
`SDL_GetWindowSurface` can not be used with 3D or the rendering API.
(See #387, #389 for details.)