### PR TITLE
Reset weapons and ammo on die

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix crash after changing audio driver via the menu.
 - [AOG] Conditions to complete the episode.
 - Render 3D scene behind "You are jamming" cheat message box.
+- [AOG] Current weapons, weapons, ammo and attack state on die with available extra live(s).
 
 ### Changed
 - [OAL] List devices with `ALC_ENUMERATE_ALL_EXT` if available.

--- a/src/3d_game.cpp
+++ b/src/3d_game.cpp
@@ -3123,15 +3123,18 @@ void Died()
 
 		gamestuff = old_gamestuff;
 
-#if 0
-		gamestate.health = 100;
-		gamestate.weapons = 1 << wp_autocharge;
-		gamestate.weapon = gamestate.chosenweapon = wp_autocharge;
+		if (get_assets_info().is_aog())
+		{
+			gamestate.health = 100;
+			gamestate.weapons = 1 << wp_autocharge;
+			gamestate.weapon = wp_autocharge;
+			gamestate.chosenweapon = wp_autocharge;
 
-		gamestate.ammo = STARTAMMO;
-		gamestate.attackframe = gamestate.attackcount =
+			gamestate.ammo = STARTAMMO;
+			gamestate.attackframe = 0;
+			gamestate.attackcount = 0;
 			gamestate.weaponframe = 0;
-#endif
+		}
 
 		DrawHealth();
 		DrawKeys();


### PR DESCRIPTION
Reset current weapon, weapons, ammo and attack state on die with available extra live(s).