### PR TITLE
Reduce checks for unknown objects in ScanInfoPlane

### DIFF
--- a/src/3d_game.cpp
+++ b/src/3d_game.cpp
@@ -237,6 +237,7 @@ void ScanInfoPlane()
 
 
 			tile = *start++;
+#if FIXME
 			//
 			// Check for tiles/icons to ignore...
 			//
@@ -255,6 +256,7 @@ void ScanInfoPlane()
 				// Ignore all values/icons on top of these tiles...
 				continue;
 			}
+#endif
 			tilehi = (tile & 0xff00) >> 8;
 			tilelo = (tile & 0xff);
 
@@ -453,22 +455,17 @@ void ScanInfoPlane()
 				break;
 
 			case 30: // Yellow Puddle
-				if (assets_info.is_aog_sw())
+				if (!assets_info.is_aog_sw())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(
-						("Yellow puddle (AOG full/PS) at (" +
-							std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					static_cast<void>(SpawnStatic(x, y, tile - 23));
 				}
-				static_cast<void>(SpawnStatic(x, y, tile - 23));
 				break;
 
 			case 71: // BFG Weapon
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(
-						("BFG (PS) at (" + std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					static_cast<void>(SpawnStatic(x, y, tile - 23));
 				}
-				static_cast<void>(SpawnStatic(x, y, tile - 23));
 				break;
 
 			case 85: // Money bag
@@ -593,15 +590,11 @@ void ScanInfoPlane()
 				break;
 
 			case 486: // Plasma Detonator
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(
-						("Plasma detonator (PS) at (" +
-							std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					SpawnHiddenOfs(en_plasma_detonator_reserve, x, y); // Spawn a reserve
+					static_cast<void>(SpawnStatic(x, y, 486 - 375));
 				}
-
-				SpawnHiddenOfs(en_plasma_detonator_reserve, x, y); // Spawn a reserve
-				static_cast<void>(SpawnStatic(x, y, 486 - 375));
 				break;
 
 			case 487: // Door rubble
@@ -696,16 +689,13 @@ void ScanInfoPlane()
 
 			case 138:
 			case 139:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Switchable arc barrier (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					//
+					// 138=off,139=on
+					//
+					SpawnBarrier(en_arc_barrier, x, y, (tile - 138) != 0);
 				}
-
-				//
-				// 138=off,139=on
-				//
-				SpawnBarrier(en_arc_barrier, x, y, (tile - 138) != 0);
 				break;
 
 				//
@@ -717,13 +707,10 @@ void ScanInfoPlane()
 				//
 			case 563: // On
 			case 562: // Off
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Switchable post barrier (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					SpawnBarrier(en_vpost_barrier, x, y, (tile - 562) != 0);
 				}
-
-				SpawnBarrier(en_vpost_barrier, x, y, (tile - 562) != 0);
 				break;
 
 
@@ -741,13 +728,10 @@ void ScanInfoPlane()
 					break;
 				}
 			case 565:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Cyclic post barrier (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					SpawnBarrier(en_vpost_barrier, x, y, 0);
 				}
-
-				SpawnBarrier(en_vpost_barrier, x, y, 0);
 				break;
 
 				//
@@ -759,13 +743,10 @@ void ScanInfoPlane()
 				//
 			case 426: // On
 			case 425: // Off
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Spike barrier (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					SpawnBarrier(en_vspike_barrier, x, y, (tile - 425) != 0);
 				}
-
-				SpawnBarrier(en_vspike_barrier, x, y, (tile - 425) != 0);
 				break;
 
 
@@ -783,12 +764,10 @@ void ScanInfoPlane()
 					break;
 				}
 			case 428:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Cyclic spike barrier (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					SpawnBarrier(en_vspike_barrier, x, y, 0);
 				}
-				SpawnBarrier(en_vspike_barrier, x, y, 0);
 				break;
 
 				//
@@ -844,13 +823,7 @@ void ScanInfoPlane()
 				//
 
 			case 141:
-				if (!assets_info.is_ps())
-				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Goldstern spawn (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
-				}
-
-				if (!loadedgame)
+				if (assets_info.is_ps() && !loadedgame)
 				{
 					if (GoldsternInfo.GoldSpawned)
 					{
@@ -1215,37 +1188,36 @@ void ScanInfoPlane()
 				// Black Ooze
 				//
 			case 313:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Black ooze (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					if (gamestate.difficulty < gd_hard)
+					{
+						break;
+					}
+					tile -= 18;
 				}
-
-				if (gamestate.difficulty < gd_hard)
+				else
 				{
 					break;
 				}
-				tile -= 18;
 			case 295:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Black ooze (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					if (gamestate.difficulty < gd_medium)
+					{
+						break;
+					}
+					tile -= 18;
 				}
-
-				if (gamestate.difficulty < gd_medium)
+				else
 				{
 					break;
 				}
-				tile -= 18;
 			case 277:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Black ooze (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					SpawnOffsetObj(en_black2_ooze, x, y);
 				}
-
-				SpawnOffsetObj(en_black2_ooze, x, y);
 				break;
 
 
@@ -1254,37 +1226,36 @@ void ScanInfoPlane()
 				// Green Ooze
 				//
 			case 322:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Green ooze (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					if (gamestate.difficulty < gd_hard)
+					{
+						break;
+					}
+					tile -= 18;
 				}
-
-				if (gamestate.difficulty < gd_hard)
+				else
 				{
 					break;
 				}
-				tile -= 18;
 			case 304:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Green ooze (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					if (gamestate.difficulty < gd_medium)
+					{
+						break;
+					}
+					tile -= 18;
 				}
-
-				if (gamestate.difficulty < gd_medium)
+				else
 				{
 					break;
 				}
-				tile -= 18;
 			case 286:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					BSTONE_THROW_DYNAMIC_SOURCE(("Green ooze (PS) at (" +
-						std::to_string(x) + ", " + std::to_string(y) + ").").c_str());
+					SpawnOffsetObj(en_green2_ooze, x, y);
 				}
-
-				SpawnOffsetObj(en_green2_ooze, x, y);
 				break;
 
 
@@ -1295,40 +1266,42 @@ void ScanInfoPlane()
 			case 355:
 			case 356:
 			case 357:
-				if (assets_info.is_aog_sw())
+				if (!assets_info.is_aog_sw())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_hard)
+					{
+						break;
+					}
+					tile -= 18;
 				}
-
-				if (gamestate.difficulty < gd_hard)
+				else
 				{
 					break;
 				}
-				tile -= 18;
 			case 336:
 			case 337:
 			case 338:
 			case 339:
-				if (assets_info.is_aog_sw())
+				if (!assets_info.is_aog_sw())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_medium)
+					{
+						break;
+					}
+					tile -= 18;
 				}
-
-				if (gamestate.difficulty < gd_medium)
+				else
 				{
 					break;
 				}
-				tile -= 18;
 			case 318:
 			case 319:
 			case 320:
 			case 321:
-				if (assets_info.is_aog_sw())
+				if (!assets_info.is_aog_sw())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					SpawnPatrol(en_volatiletransport, x, y, tile - 318);
 				}
-
-				SpawnPatrol(en_volatiletransport, x, y, tile - 318);
 				break;
 
 				//
@@ -1354,27 +1327,34 @@ void ScanInfoPlane()
 				// Cyborg Warrior
 				//
 			case 603:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_hard)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_hard)
+				else
 				{
 					break;
 				}
 			case 585:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_medium)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_medium)
+				else
 				{
 					break;
 				}
 			case 250:
-				SpawnOffsetObj(en_cyborg_warrior, x, y);
+				if (assets_info.is_ps())
+				{
+					SpawnOffsetObj(en_cyborg_warrior, x, y);
+				}
 				break;
 
 
@@ -1382,139 +1362,174 @@ void ScanInfoPlane()
 				// Spider Mutant
 				//
 			case 601:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_hard)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_hard)
+				else
 				{
 					break;
 				}
 			case 583:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_medium)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_medium)
+				else
 				{
 					break;
 				}
 			case 232:
-				SpawnOffsetObj(en_spider_mutant, x, y);
+				if (assets_info.is_ps())
+				{
+					SpawnOffsetObj(en_spider_mutant, x, y);
+				}
 				break;
 
 				//
 				// Acid Dragon
 				//
 			case 605:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_hard)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_hard)
+				else
 				{
 					break;
 				}
 			case 587:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_medium)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_medium)
+				else
 				{
 					break;
 				}
 
 			case 268:
-				SpawnOffsetObj(en_acid_dragon, x, y);
+				if (assets_info.is_ps())
+				{
+					SpawnOffsetObj(en_acid_dragon, x, y);
+				}
 				break;
 
 				//
 				// Breather beast
 				//
 			case 602:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_hard)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_hard)
+				else
 				{
 					break;
 				}
 			case 584:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_medium)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_medium)
+				else
 				{
 					break;
 				}
 
 			case 233:
-				SpawnOffsetObj(en_breather_beast, x, y);
+				if (assets_info.is_ps())
+				{
+					SpawnOffsetObj(en_breather_beast, x, y);
+				}
 				break;
 
 				//
 				// Mech Guardian
 				//
 			case 606:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_hard)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_hard)
+				else
 				{
 					break;
 				}
 			case 588:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_medium)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_medium)
+				else
 				{
 					break;
 				}
 
 			case 269:
-				SpawnOffsetObj(en_mech_guardian, x, y);
+				if (assets_info.is_ps())
+				{
+					SpawnOffsetObj(en_mech_guardian, x, y);
+				}
 				break;
 
 				//
 				// Reptilian Warrior
 				//
 			case 604:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_hard)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_hard)
+				else
 				{
 					break;
 				}
 			case 586:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					if (gamestate.difficulty < gd_medium)
+					{
+						break;
+					}
 				}
-
-				if (gamestate.difficulty < gd_medium)
+				else
 				{
 					break;
 				}
 
 			case 251:
-				SpawnOffsetObj(en_reptilian_warrior, x, y);
+				if (assets_info.is_ps())
+				{
+					SpawnOffsetObj(en_reptilian_warrior, x, y);
+				}
 				break;
 
 
@@ -1718,88 +1733,92 @@ void ScanInfoPlane()
 				// Morphing Brown/LBlue Post -> Spider Mutant
 				//
 			case 610:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
-				}
-
-				if (gamestate.difficulty < gd_hard)
-				{
-					scan_value = 0xff;
-				}
-
-			case 609:
-				if (!assets_info.is_ps())
-				{
-					INVALID_ACTOR_ERR(x, y);
-				}
-
-				if (gamestate.difficulty < gd_medium)
-				{
-					scan_value = 0xff;
-				}
-
-			case 608:
-				if (!assets_info.is_ps())
-				{
-					INVALID_ACTOR_ERR(x, y);
-				}
-
-				if (scan_value == 0xff)
-				{
-					static_cast<void>(SpawnStatic(x, y, 402 - 315));
+					if (gamestate.difficulty < gd_hard)
+					{
+						scan_value = 0xff;
+					}
 				}
 				else
 				{
-					AddTotalPoints(actor_points[en_spider_mutant]);
-					AddTotalEnemy(1);
-					SpawnOffsetObj(en_morphing_spider_mutant, x, y);
+					break;
 				}
-				scan_value = 0xffff;
+
+			case 609:
+				if (assets_info.is_ps())
+				{
+					if (gamestate.difficulty < gd_medium)
+					{
+						scan_value = 0xff;
+					}
+				}
+				else
+				{
+					break;
+				}
+
+			case 608:
+				if (assets_info.is_ps())
+				{
+					if (scan_value == 0xff)
+					{
+						static_cast<void>(SpawnStatic(x, y, 402 - 315));
+					}
+					else
+					{
+						AddTotalPoints(actor_points[en_spider_mutant]);
+						AddTotalEnemy(1);
+						SpawnOffsetObj(en_morphing_spider_mutant, x, y);
+					}
+					scan_value = 0xffff;
+				}
 				break;
 
 
 				// Morphing Gray/Green Post -> Reptilian Warrior
 				//
 			case 592:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
-				}
-
-				if (gamestate.difficulty < gd_hard)
-				{
-					scan_value = 0xff;
-				}
-
-			case 591:
-				if (!assets_info.is_ps())
-				{
-					INVALID_ACTOR_ERR(x, y);
-				}
-
-				if (gamestate.difficulty < gd_medium)
-				{
-					scan_value = 0xff;
-				}
-
-			case 590:
-				if (!assets_info.is_ps())
-				{
-					INVALID_ACTOR_ERR(x, y);
-				}
-
-				if (scan_value == 0xff)
-				{
-					static_cast<void>(SpawnStatic(x, y, 403 - 315));
+					if (gamestate.difficulty < gd_hard)
+					{
+						scan_value = 0xff;
+					}
 				}
 				else
 				{
-					AddTotalPoints(actor_points[en_reptilian_warrior]);
-					AddTotalEnemy(1);
-					SpawnOffsetObj(en_morphing_reptilian_warrior, x, y);
+					break;
 				}
-				scan_value = 0xffff;
+
+			case 591:
+				if (assets_info.is_ps())
+				{
+					if (gamestate.difficulty < gd_medium)
+					{
+						scan_value = 0xff;
+					}
+				}
+				else
+				{
+					break;
+				}
+
+			case 590:
+				if (assets_info.is_ps())
+				{
+					if (scan_value == 0xff)
+					{
+						static_cast<void>(SpawnStatic(x, y, 403 - 315));
+					}
+					else
+					{
+						AddTotalPoints(actor_points[en_reptilian_warrior]);
+						AddTotalEnemy(1);
+						SpawnOffsetObj(en_morphing_reptilian_warrior, x, y);
+					}
+					scan_value = 0xffff;
+				}
 				break;
 
 
@@ -1807,44 +1826,46 @@ void ScanInfoPlane()
 				// Morphing Statue -> Blue Boy
 				//
 			case 628:
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
-				}
-
-				if (gamestate.difficulty < gd_hard)
-				{
-					scan_value = 0xff;
-				}
-
-			case 627:
-				if (!assets_info.is_ps())
-				{
-					INVALID_ACTOR_ERR(x, y);
-				}
-
-				if (gamestate.difficulty < gd_medium)
-				{
-					scan_value = 0xff;
-				}
-
-			case 626:
-				if (!assets_info.is_ps())
-				{
-					INVALID_ACTOR_ERR(x, y);
-				}
-
-				if (scan_value == 0xff)
-				{
-					static_cast<void>(SpawnStatic(x, y, 48 - 23));
+					if (gamestate.difficulty < gd_hard)
+					{
+						scan_value = 0xff;
+					}
 				}
 				else
 				{
-					AddTotalPoints(actor_points[en_mutant_human2]);
-					AddTotalEnemy(1);
-					SpawnOffsetObj(en_morphing_mutanthuman2, x, y);
+					break;
 				}
-				scan_value = 0xffff;
+
+			case 627:
+				if (assets_info.is_ps())
+				{
+					if (gamestate.difficulty < gd_medium)
+					{
+						scan_value = 0xff;
+					}
+				}
+				else
+				{
+					break;
+				}
+
+			case 626:
+				if (assets_info.is_ps())
+				{
+					if (scan_value == 0xff)
+					{
+						static_cast<void>(SpawnStatic(x, y, 48 - 23));
+					}
+					else
+					{
+						AddTotalPoints(actor_points[en_mutant_human2]);
+						AddTotalEnemy(1);
+						SpawnOffsetObj(en_morphing_mutanthuman2, x, y);
+					}
+					scan_value = 0xffff;
+				}
 				break;
 
 
@@ -2205,12 +2226,10 @@ void ScanInfoPlane()
 			case 631: // FINAL BOSS 2
 			case 632: // FINAL BOSS 3
 			case 633: // FINAL BOSS 4
-				if (!assets_info.is_ps())
+				if (assets_info.is_ps())
 				{
-					INVALID_ACTOR_ERR(x, y);
+					SpawnOffsetObj(static_cast<enemy_t>(en_final_boss1 + tile - 630), x, y);
 				}
-
-				SpawnOffsetObj(static_cast<enemy_t>(en_final_boss1 + tile - 630), x, y);
 				break;
 			}
 

--- a/src/3d_main.cpp
+++ b/src/3d_main.cpp
@@ -10744,7 +10744,7 @@ const std::string& get_profile_dir()
 			profile_dir.resize(buffer_size);
 
 			const auto path_size = bstone::sys::SpecialPath::get_user_specific_data_path(
-				"bibendovsky?",
+				"bibendovsky",
 				"bstone",
 				&profile_dir.front(),
 				buffer_size);


### PR DESCRIPTION
Custom maps may contain unknown objects.
Just ignore them.
See for example #462.