### PR TITLE
Vulkan renderer fixes for Wayland (and possibly other environments)

### DIFF
--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -2075,24 +2075,27 @@ void VkR3rImpl::swapchain_acquire_next_image()
 			return;
 		}
 	}
-	const VkResult vk_result = context_.vkAcquireNextImageKHR(
-		/* device */      context_.device.get(),
-		/* swapchain */   context_.swapchain.get(),
-		/* timeout */     UINT64_MAX,
-		/* semaphore */   context_.image_available_semaphore.get(),
-		/* fence */       VkFence{},
-		/* pImageIndex */ &context_.swapchain_image_index
-	);
-	switch (vk_result)
+	for (;;)
 	{
-		case VK_ERROR_OUT_OF_DATE_KHR:
-			recreate_swapchain();
-			break;
-		case VK_SUBOPTIMAL_KHR:
-			break;
-		default:
-			ensure_vk_result(vk_result, "vkAcquireNextImageKHR");
-			return;
+		const VkResult vk_result = context_.vkAcquireNextImageKHR(
+			/* device */      context_.device.get(),
+			/* swapchain */   context_.swapchain.get(),
+			/* timeout */     UINT64_MAX,
+			/* semaphore */   context_.image_available_semaphore.get(),
+			/* fence */       VkFence{},
+			/* pImageIndex */ &context_.swapchain_image_index
+		);
+		switch (vk_result)
+		{
+			case VK_ERROR_OUT_OF_DATE_KHR:
+				recreate_swapchain();
+				break;
+			case VK_SUBOPTIMAL_KHR:
+				return;
+			default:
+				ensure_vk_result(vk_result, "vkAcquireNextImageKHR");
+				return;
+		}
 	}
 }
 


### PR DESCRIPTION
Not all platforms emit VK_ERROR_OUT_OF_DATE or VK_SUBOPTIMAL when the window is resized (e.g. Wayland surfaces are not tied to the window size), so using only these return codes to trigger swapchain recreation is unreliable. Recreate the swapchain whenever the window is resized.

Additionally, when recreating the swapchain, vkAcquireNextImage may not always be called, leading to the image index being invalid. A new image must always be acquired when recreating the swapchain.

Fixes #524