### PR TITLE
Add a minimal Valve Data Format (KeyValues) reader

### DIFF
--- a/src/bstone/CMakeLists.txt
+++ b/src/bstone/CMakeLists.txt
@@ -565,6 +565,8 @@ source_group("bstone/renderer/3d/gl" FILES ${BSTONE_BSTONE_RENDERER_3D_GL_SOURCE
 # ---------------------------------------------------------------------------
 
 set(BSTONE_BSTONE_RENDERER_3D_VK_SOURCES
+	src/bstone_vdf.cpp
+	src/bstone_vdf.h
 	src/bstone_vk_r3r.cpp
 	src/bstone_vk_r3r.h
 	src/bstone_vk_r3r_buffer.cpp

--- a/src/bstone/src/bstone_vdf.cpp
+++ b/src/bstone/src/bstone_vdf.cpp
@@ -1,0 +1,221 @@
+/*
+BStone: Unofficial source port of Blake Stone: Aliens of Gold and Blake Stone: Planet Strike
+Copyright (c) 2026 Boris I. Bendovsky (bibendovsky@hotmail.com) and Contributors
+SPDX-License-Identifier: MIT
+*/
+
+// Minimal reader for Valve Data Format (VDF, also known as KeyValues) text.
+
+#include "bstone_vdf.h"
+#include "bstone_ascii.h"
+#include <cstddef>
+
+namespace bstone {
+
+namespace {
+
+// Guards against stack exhaustion from a corrupt or hostile file. Steam's own
+// files nest three or four levels deep.
+constexpr int max_depth = 32;
+
+constexpr char utf8_bom[] = "\xEF\xBB\xBF";
+constexpr std::size_t utf8_bom_size = 3;
+
+bool is_space(char ch) noexcept
+{
+	return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n';
+}
+
+// A bare token ends at whitespace, a brace or a quote.
+bool is_token_end(char ch) noexcept
+{
+	return is_space(ch) || ch == '{' || ch == '}' || ch == '"';
+}
+
+class VdfParser
+{
+public:
+	VdfParser(std::string_view text) noexcept
+		:
+		text_{text}
+	{
+		// Steam writes UTF-8; some editors add a byte-order mark.
+		if (text_.size() >= utf8_bom_size && text_.compare(0, utf8_bom_size, utf8_bom) == 0)
+		{
+			pos_ = utf8_bom_size;
+		}
+	}
+
+	// Parses the top-level sequence of entries into `root`.
+	bool parse(VdfNode& root)
+	{
+		while (true)
+		{
+			skip_space_and_comments();
+			if (is_eof())
+				return true;
+			// A stray closing brace at the top level is malformed.
+			if (peek() == '}')
+				return false;
+			VdfNode child;
+			if (!parse_entry(child, 0))
+				return false;
+			root.children.push_back(std::move(child));
+		}
+	}
+
+private:
+	std::string_view text_;
+	std::size_t pos_{};
+
+	bool is_eof() const noexcept { return pos_ >= text_.size(); }
+	char peek() const noexcept { return text_[pos_]; }
+
+	void skip_space_and_comments() noexcept
+	{
+		while (!is_eof())
+		{
+			if (is_space(peek()))
+			{
+				++pos_;
+			}
+			else if (peek() == '/' && pos_ + 1 < text_.size() && text_[pos_ + 1] == '/')
+			{
+				while (!is_eof() && peek() != '\n')
+					++pos_;
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+
+	// Reads a quoted or bare token. Returns false on an unterminated quote.
+	bool parse_token(std::string& token)
+	{
+		token.clear();
+		if (peek() != '"')
+		{
+			while (!is_eof() && !is_token_end(peek()))
+			{
+				token += text_[pos_];
+				++pos_;
+			}
+			return !token.empty();
+		}
+		++pos_; // Opening quote.
+		while (true)
+		{
+			if (is_eof())
+				return false; // Unterminated.
+			const char ch = text_[pos_];
+			if (ch == '"')
+			{
+				++pos_; // Closing quote.
+				return true;
+			}
+			if (ch == '\\')
+			{
+				++pos_;
+				if (is_eof())
+					return false; // Trailing backslash.
+				// Steam writes Windows paths as "D:\\Games", so `\\` must collapse
+				// to a single separator. An unknown escape keeps its literal
+				// character, which is what KeyValues does.
+				const char escaped = text_[pos_];
+				switch (escaped)
+				{
+					case 'n': token += '\n'; break;
+					case 't': token += '\t'; break;
+					default: token += escaped; break;
+				}
+				++pos_;
+				continue;
+			}
+			token += ch;
+			++pos_;
+		}
+	}
+
+	// Parses `name` followed by either a value token or a `{ ... }` block.
+	bool parse_entry(VdfNode& node, int depth)
+	{
+		if (depth >= max_depth)
+			return false;
+		if (!parse_token(node.name))
+			return false;
+		skip_space_and_comments();
+		if (is_eof())
+			return false; // A name with neither value nor block.
+		if (peek() != '{')
+			return parse_token(node.value);
+		++pos_; // Opening brace.
+		while (true)
+		{
+			skip_space_and_comments();
+			if (is_eof())
+				return false; // Unterminated block.
+			if (peek() == '}')
+			{
+				++pos_; // Closing brace.
+				return true;
+			}
+			VdfNode child;
+			if (!parse_entry(child, depth + 1))
+				return false;
+			node.children.push_back(std::move(child));
+		}
+	}
+};
+
+bool are_names_equal(std::string_view lhs, std::string_view rhs) noexcept
+{
+	if (lhs.size() != rhs.size())
+		return false;
+	for (std::size_t i = 0; i < lhs.size(); ++i)
+	{
+		if (ascii::to_lower(lhs[i]) != ascii::to_lower(rhs[i]))
+			return false;
+	}
+	return true;
+}
+
+} // namespace
+
+bool VdfNode::is_object() const noexcept
+{
+	return !children.empty();
+}
+
+const VdfNode* VdfNode::find_child(std::string_view child_name) const noexcept
+{
+	for (const VdfNode& child : children)
+	{
+		if (are_names_equal(child.name, child_name))
+			return &child;
+	}
+	return nullptr;
+}
+
+std::string_view VdfNode::find_value(std::string_view child_name) const noexcept
+{
+	const VdfNode* const child = find_child(child_name);
+	return child != nullptr ? std::string_view{child->value} : std::string_view{};
+}
+
+bool parse_vdf(std::string_view text, VdfNode& root) noexcept
+try {
+	root = VdfNode{};
+	VdfParser parser{text};
+	if (parser.parse(root))
+		return true;
+	root = VdfNode{};
+	return false;
+} catch (...) {
+	// The only plausible failure is allocation; report it like malformed input.
+	root = VdfNode{};
+	return false;
+}
+
+} // namespace bstone

--- a/src/bstone/src/bstone_vdf.cpp
+++ b/src/bstone/src/bstone_vdf.cpp
@@ -151,6 +151,7 @@ private:
 		if (peek() != '{')
 			return parse_token(node.value);
 		++pos_; // Opening brace.
+		node.is_block = true;
 		while (true)
 		{
 			skip_space_and_comments();
@@ -185,7 +186,7 @@ bool are_names_equal(std::string_view lhs, std::string_view rhs) noexcept
 
 bool VdfNode::is_object() const noexcept
 {
-	return !children.empty();
+	return is_block;
 }
 
 const VdfNode* VdfNode::find_child(std::string_view child_name) const noexcept

--- a/src/bstone/src/bstone_vdf.h
+++ b/src/bstone/src/bstone_vdf.h
@@ -20,12 +20,17 @@ SPDX-License-Identifier: MIT
 
 namespace bstone {
 
-// A node is either an object (it has children) or a leaf (it has a value).
+// A node is either an object (it was written as a `{ ... }` block) or a leaf (it
+// has a value).
 struct VdfNode
 {
 	std::string name;
 	std::string value; // Meaningful only for a leaf.
 	std::vector<VdfNode> children;
+	// Set when the node was written as a block. An empty block is real - a library
+	// folder with no games installed writes `"apps" {}` - so emptiness of `children`
+	// must not be used to tell an object from a leaf.
+	bool is_block{};
 
 	bool is_object() const noexcept;
 

--- a/src/bstone/src/bstone_vdf.h
+++ b/src/bstone/src/bstone_vdf.h
@@ -1,0 +1,50 @@
+/*
+BStone: Unofficial source port of Blake Stone: Aliens of Gold and Blake Stone: Planet Strike
+Copyright (c) 2026 Boris I. Bendovsky (bibendovsky@hotmail.com) and Contributors
+SPDX-License-Identifier: MIT
+*/
+
+// Minimal reader for Valve Data Format (VDF, also known as KeyValues) text.
+//
+// Supports only what Steam's `libraryfolders.vdf` and `appmanifest_*.acf` actually
+// use: quoted and bare tokens, nested objects, `//` comments and the `\\`, `\"`,
+// `\n`, `\t` escapes. Binary VDF, `#base`/`#include` and platform conditionals are
+// out of scope.
+
+#ifndef BSTONE_VDF_INCLUDED
+#define BSTONE_VDF_INCLUDED
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace bstone {
+
+// A node is either an object (it has children) or a leaf (it has a value).
+struct VdfNode
+{
+	std::string name;
+	std::string value; // Meaningful only for a leaf.
+	std::vector<VdfNode> children;
+
+	bool is_object() const noexcept;
+
+	// Finds a direct child by name. Names are compared case-insensitively (ASCII),
+	// as KeyValues does, which also makes the caller immune to Steam's renaming of
+	// the root key from "LibraryFolders" to "libraryfolders".
+	// Returns null when there is no such child.
+	const VdfNode* find_child(std::string_view child_name) const noexcept;
+
+	// Value of a direct leaf child, or an empty view when there is no such child.
+	std::string_view find_value(std::string_view child_name) const noexcept;
+};
+
+// Parses VDF text into `root`, whose children are the top-level entries.
+//
+// Returns false if the text is malformed, in which case `root` is left empty.
+// Never throws, so a corrupt file on disk is reported rather than propagated.
+bool parse_vdf(std::string_view text, VdfNode& root) noexcept;
+
+} // namespace bstone
+
+#endif // BSTONE_VDF_INCLUDED

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -89,6 +89,8 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_win32_wstring.h
 		../../../bstone/src/bstone_sys_file.h
 		../../../bstone/src/bstone_sys_file_sdl.cpp
+		../../../bstone/src/bstone_vdf.cpp
+		../../../bstone/src/bstone_vdf.h
 	PRIVATE
 		src/bstone_tests_ascii.cpp
 		src/bstone_tests_char_conv.cpp
@@ -110,6 +112,7 @@ target_sources(bstone_tests
 		src/bstone_tests_crc32.cpp
 		src/bstone_tests_win32_registry_key.cpp
 		src/bstone_tests_four_cc.cpp
+		src/bstone_tests_vdf.cpp
 	PRIVATE
 		src/bstone_tester.cpp
 		src/bstone_tester.h

--- a/src/tests/src/tests/src/bstone_tests_vdf.cpp
+++ b/src/tests/src/tests/src/bstone_tests_vdf.cpp
@@ -258,6 +258,75 @@ void test_e18zvbckv4wvf97j()
 		obj != nullptr && obj->is_object());
 }
 
+// bool VdfNode::is_object() const
+// An empty block is still an object. Steam writes `"apps" {}` for a library
+// folder with nothing installed in it.
+void test_pw1tqk4vsyn8j2ba()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"apps\"\n{\n}\n\"scalar\" \"\"", root);
+	const auto* const apps = root.find_child("apps");
+	const auto* const scalar = root.find_child("scalar");
+	tester.check(
+		is_parsed &&
+		apps != nullptr && apps->is_object() && apps->children.empty() &&
+		scalar != nullptr && !scalar->is_object());
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Brackets inside a quoted value are literal, not a platform conditional.
+void test_74n2wcbzsp2hbcyc()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"path\" \"D:\\\\Games\\\\[Steam]\"", root);
+	tester.check(is_parsed && root.find_value("path") == "D:\\Games\\[Steam]");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// A UNC library path only survives if escapes are processed.
+void test_bnbx7yrpc5f5owsc()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"path\" \"\\\\\\\\NAS\\\\Share\"", root);
+	tester.check(is_parsed && root.find_value("path") == "\\\\NAS\\Share");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Scalar siblings sit alongside the numbered library entries, so a caller must be
+// able to tell them apart.
+void test_yqbm5f8hbnjy1mjb()
+{
+	constexpr auto text =
+		"\"libraryfolders\"\n"
+		"{\n"
+		"\t\"contentstatsid\"\t\t\"123456789\"\n"
+		"\t\"0\"\n"
+		"\t{\n"
+		"\t\t\"path\"\t\t\"/steam\"\n"
+		"\t}\n"
+		"}\n";
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf(text, root);
+	const auto* const folders = root.find_child("libraryfolders");
+	const auto* const stats = folders != nullptr ? folders->find_child("contentstatsid") : nullptr;
+	const auto* const entry = folders != nullptr ? folders->find_child("0") : nullptr;
+	tester.check(
+		is_parsed &&
+		folders != nullptr && folders->children.size() == 2 &&
+		stats != nullptr && !stats->is_object() &&
+		entry != nullptr && entry->is_object() &&
+		entry->find_value("path") == "/steam");
+}
+
+// const VdfNode* VdfNode::find_child(std::string_view) const
+// Duplicate keys are kept, and the first one wins, as KeyValues does.
+void test_h1i2pvjnz6ftwgg2()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"k\" \"first\" \"k\" \"second\"", root);
+	tester.check(is_parsed && root.children.size() == 2 && root.find_value("k") == "first");
+}
+
 // ==========================================================================
 
 // bool parse_vdf(std::string_view, VdfNode&)
@@ -348,6 +417,11 @@ private:
 		tester.register_test("Vdf#5lariqpxs8t1lb69", test_5lariqpxs8t1lb69);
 		tester.register_test("Vdf#lcle5r4sogsq8xyb", test_lcle5r4sogsq8xyb);
 		tester.register_test("Vdf#e18zvbckv4wvf97j", test_e18zvbckv4wvf97j);
+		tester.register_test("Vdf#pw1tqk4vsyn8j2ba", test_pw1tqk4vsyn8j2ba);
+		tester.register_test("Vdf#74n2wcbzsp2hbcyc", test_74n2wcbzsp2hbcyc);
+		tester.register_test("Vdf#bnbx7yrpc5f5owsc", test_bnbx7yrpc5f5owsc);
+		tester.register_test("Vdf#yqbm5f8hbnjy1mjb", test_yqbm5f8hbnjy1mjb);
+		tester.register_test("Vdf#h1i2pvjnz6ftwgg2", test_h1i2pvjnz6ftwgg2);
 	}
 
 	void register_malformed()

--- a/src/tests/src/tests/src/bstone_tests_vdf.cpp
+++ b/src/tests/src/tests/src/bstone_tests_vdf.cpp
@@ -1,0 +1,365 @@
+#include <string>
+#include "bstone_vdf.h"
+#include "bstone_tester.h"
+
+namespace {
+
+auto tester = bstone::Tester{};
+
+// ==========================================================================
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Empty text.
+void test_c6924ee2i0oiegx3()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("", root);
+	tester.check(is_parsed && root.children.empty());
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// A single key/value pair.
+void test_38rta6pubumw927k()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"key\" \"value\"", root);
+	tester.check(
+		is_parsed &&
+		root.children.size() == 1 &&
+		root.children[0].name == "key" &&
+		root.children[0].value == "value" &&
+		!root.children[0].is_object());
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// A nested object.
+void test_mtdqyztui42hbkva()
+{
+	constexpr auto text =
+		"\"outer\"\n"
+		"{\n"
+		"\t\"inner\"\t\"1\"\n"
+		"}\n";
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf(text, root);
+	const auto* const outer = root.find_child("outer");
+	tester.check(
+		is_parsed &&
+		outer != nullptr &&
+		outer->is_object() &&
+		outer->find_value("inner") == "1");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Current libraryfolders.vdf: numeric keys map to objects carrying "path".
+void test_10iqosiccebjqz79()
+{
+	constexpr auto text =
+		"\"libraryfolders\"\n"
+		"{\n"
+		"\t\"0\"\n"
+		"\t{\n"
+		"\t\t\"path\"\t\t\"/home/user/.local/share/Steam\"\n"
+		"\t\t\"label\"\t\t\"\"\n"
+		"\t\t\"apps\"\n"
+		"\t\t{\n"
+		"\t\t\t\"358190\"\t\t\"123456\"\n"
+		"\t\t}\n"
+		"\t}\n"
+		"\t\"1\"\n"
+		"\t{\n"
+		"\t\t\"path\"\t\t\"/mnt/games/SteamLibrary\"\n"
+		"\t}\n"
+		"}\n";
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf(text, root);
+	const auto* const folders = root.find_child("libraryfolders");
+	const auto* const first = folders != nullptr ? folders->find_child("0") : nullptr;
+	const auto* const second = folders != nullptr ? folders->find_child("1") : nullptr;
+	const auto* const apps = first != nullptr ? first->find_child("apps") : nullptr;
+	tester.check(
+		is_parsed &&
+		folders != nullptr &&
+		folders->children.size() == 2 &&
+		first != nullptr &&
+		first->find_value("path") == "/home/user/.local/share/Steam" &&
+		first->find_value("label").empty() &&
+		second != nullptr &&
+		second->find_value("path") == "/mnt/games/SteamLibrary" &&
+		apps != nullptr &&
+		apps->find_value("358190") == "123456");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Legacy libraryfolders.vdf: numeric keys map straight to a path string, and the
+// root key was capitalised differently.
+void test_z9aotytq2nxntmts()
+{
+	constexpr auto text =
+		"\"LibraryFolders\"\n"
+		"{\n"
+		"\t\"TimeNextStatsReport\"\t\t\"1600000000\"\n"
+		"\t\"1\"\t\t\"D:\\\\SteamLibrary\"\n"
+		"}\n";
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf(text, root);
+	// Lookup is case-insensitive, so the same call finds either spelling.
+	const auto* const folders = root.find_child("libraryfolders");
+	tester.check(
+		is_parsed &&
+		folders != nullptr &&
+		folders->find_value("1") == "D:\\SteamLibrary");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// appmanifest_*.acf.
+void test_lo89hdqsgqjdxx40()
+{
+	constexpr auto text =
+		"\"AppState\"\n"
+		"{\n"
+		"\t\"appid\"\t\t\"358190\"\n"
+		"\t\"name\"\t\t\"Blake Stone: Aliens of Gold\"\n"
+		"\t\"StateFlags\"\t\t\"4\"\n"
+		"\t\"installdir\"\t\t\"Blake Stone - Aliens of Gold\"\n"
+		"\t\"InstalledDepots\"\n"
+		"\t{\n"
+		"\t\t\"358191\"\n"
+		"\t\t{\n"
+		"\t\t\t\"manifest\"\t\t\"123\"\n"
+		"\t\t}\n"
+		"\t}\n"
+		"}\n";
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf(text, root);
+	const auto* const app_state = root.find_child("AppState");
+	tester.check(
+		is_parsed &&
+		app_state != nullptr &&
+		app_state->find_value("appid") == "358190" &&
+		app_state->find_value("StateFlags") == "4" &&
+		app_state->find_value("installdir") == "Blake Stone - Aliens of Gold");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Escapes: Steam writes Windows paths with doubled separators.
+void test_u8vx20e1ptkzq6px()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"path\" \"C:\\\\Program Files (x86)\\\\Steam\"", root);
+	tester.check(is_parsed && root.find_value("path") == "C:\\Program Files (x86)\\Steam");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Escapes: quote, newline and tab.
+void test_xga7pncvvw9taohu()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"k\" \"a\\\"b\\nc\\td\"", root);
+	tester.check(is_parsed && root.find_value("k") == "a\"b\nc\td");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// An unknown escape keeps its literal character.
+void test_oromby1njuckga1u()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"k\" \"a\\qb\"", root);
+	tester.check(is_parsed && root.find_value("k") == "aqb");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Line comments are ignored.
+void test_maicoqzy0n4k78oc()
+{
+	constexpr auto text =
+		"// leading comment\n"
+		"\"outer\"\n"
+		"{\n"
+		"\t// inner comment\n"
+		"\t\"a\"\t\"1\" // trailing comment\n"
+		"}\n";
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf(text, root);
+	const auto* const outer = root.find_child("outer");
+	tester.check(is_parsed && outer != nullptr && outer->find_value("a") == "1");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Bare (unquoted) tokens.
+void test_sil9xbvqosqpuelr()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("outer { key value }", root);
+	const auto* const outer = root.find_child("outer");
+	tester.check(is_parsed && outer != nullptr && outer->find_value("key") == "value");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// A UTF-8 byte-order mark is skipped.
+void test_8vg16na7z6o5c88f()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\xEF\xBB\xBF\"key\" \"value\"", root);
+	tester.check(is_parsed && root.find_value("key") == "value");
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// CRLF line endings.
+void test_3mu0khfb2i9jxb1k()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"outer\"\r\n{\r\n\t\"a\"\t\"1\"\r\n}\r\n", root);
+	const auto* const outer = root.find_child("outer");
+	tester.check(is_parsed && outer != nullptr && outer->find_value("a") == "1");
+}
+
+// ==========================================================================
+
+// const VdfNode* VdfNode::find_child(std::string_view) const
+// Lookup is case-insensitive.
+void test_c29k06zz2kyho37k()
+{
+	auto root = bstone::VdfNode{};
+	bstone::parse_vdf("\"MiXeD\" \"1\"", root);
+	tester.check(
+		root.find_child("mixed") != nullptr &&
+		root.find_child("MIXED") != nullptr &&
+		root.find_child("MiXeD") != nullptr);
+}
+
+// const VdfNode* VdfNode::find_child(std::string_view) const
+// A missing child yields null.
+void test_5lariqpxs8t1lb69()
+{
+	auto root = bstone::VdfNode{};
+	bstone::parse_vdf("\"key\" \"value\"", root);
+	tester.check(root.find_child("absent") == nullptr);
+}
+
+// std::string_view VdfNode::find_value(std::string_view) const
+// A missing child yields an empty value.
+void test_lcle5r4sogsq8xyb()
+{
+	auto root = bstone::VdfNode{};
+	bstone::parse_vdf("\"key\" \"value\"", root);
+	tester.check(root.find_value("absent").empty());
+}
+
+// bool VdfNode::is_object() const
+void test_e18zvbckv4wvf97j()
+{
+	auto root = bstone::VdfNode{};
+	bstone::parse_vdf("\"leaf\" \"1\" \"obj\" { \"a\" \"2\" }", root);
+	const auto* const leaf = root.find_child("leaf");
+	const auto* const obj = root.find_child("obj");
+	tester.check(
+		leaf != nullptr && !leaf->is_object() &&
+		obj != nullptr && obj->is_object());
+}
+
+// ==========================================================================
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Malformed: unterminated quoted string.
+void test_gty4pdk0fdvl7b2x()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"key\" \"unterminated", root);
+	tester.check(!is_parsed && root.children.empty());
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Malformed: unterminated block.
+void test_ko3ztf6uag1gfbip()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"outer\"\n{\n\t\"a\"\t\"1\"\n", root);
+	tester.check(!is_parsed && root.children.empty());
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Malformed: a stray closing brace.
+void test_z3lwoanvegbfdmvi()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("}", root);
+	tester.check(!is_parsed && root.children.empty());
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Malformed: a key with neither a value nor a block.
+void test_ifv09e68sbis1bcm()
+{
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf("\"lonely\"", root);
+	tester.check(!is_parsed && root.children.empty());
+}
+
+// bool parse_vdf(std::string_view, VdfNode&)
+// Malformed: nesting deeper than the parser accepts is rejected rather than
+// overflowing the stack.
+void test_0lwm7ztdn1hypbr1()
+{
+	auto text = std::string{};
+	constexpr auto depth = 200;
+	for (auto i = 0; i < depth; ++i)
+		text += "\"a\"\n{\n";
+	for (auto i = 0; i < depth; ++i)
+		text += "}\n";
+	auto root = bstone::VdfNode{};
+	const auto is_parsed = bstone::parse_vdf(text, root);
+	tester.check(!is_parsed && root.children.empty());
+}
+
+// ==========================================================================
+
+class Registrator
+{
+public:
+	Registrator()
+	{
+		register_parse();
+		register_lookup();
+		register_malformed();
+	}
+
+private:
+	void register_parse()
+	{
+		tester.register_test("Vdf#c6924ee2i0oiegx3", test_c6924ee2i0oiegx3);
+		tester.register_test("Vdf#38rta6pubumw927k", test_38rta6pubumw927k);
+		tester.register_test("Vdf#mtdqyztui42hbkva", test_mtdqyztui42hbkva);
+		tester.register_test("Vdf#10iqosiccebjqz79", test_10iqosiccebjqz79);
+		tester.register_test("Vdf#z9aotytq2nxntmts", test_z9aotytq2nxntmts);
+		tester.register_test("Vdf#lo89hdqsgqjdxx40", test_lo89hdqsgqjdxx40);
+		tester.register_test("Vdf#u8vx20e1ptkzq6px", test_u8vx20e1ptkzq6px);
+		tester.register_test("Vdf#xga7pncvvw9taohu", test_xga7pncvvw9taohu);
+		tester.register_test("Vdf#oromby1njuckga1u", test_oromby1njuckga1u);
+		tester.register_test("Vdf#maicoqzy0n4k78oc", test_maicoqzy0n4k78oc);
+		tester.register_test("Vdf#sil9xbvqosqpuelr", test_sil9xbvqosqpuelr);
+		tester.register_test("Vdf#8vg16na7z6o5c88f", test_8vg16na7z6o5c88f);
+		tester.register_test("Vdf#3mu0khfb2i9jxb1k", test_3mu0khfb2i9jxb1k);
+	}
+
+	void register_lookup()
+	{
+		tester.register_test("Vdf#c29k06zz2kyho37k", test_c29k06zz2kyho37k);
+		tester.register_test("Vdf#5lariqpxs8t1lb69", test_5lariqpxs8t1lb69);
+		tester.register_test("Vdf#lcle5r4sogsq8xyb", test_lcle5r4sogsq8xyb);
+		tester.register_test("Vdf#e18zvbckv4wvf97j", test_e18zvbckv4wvf97j);
+	}
+
+	void register_malformed()
+	{
+		tester.register_test("Vdf#gty4pdk0fdvl7b2x", test_gty4pdk0fdvl7b2x);
+		tester.register_test("Vdf#ko3ztf6uag1gfbip", test_ko3ztf6uag1gfbip);
+		tester.register_test("Vdf#z3lwoanvegbfdmvi", test_z3lwoanvegbfdmvi);
+		tester.register_test("Vdf#ifv09e68sbis1bcm", test_ifv09e68sbis1bcm);
+		tester.register_test("Vdf#0lwm7ztdn1hypbr1", test_0lwm7ztdn1hypbr1);
+	}
+};
+
+auto registrator = Registrator{};
+
+} // namespace


### PR DESCRIPTION
> [!NOTE]
> **Depends on #561** — this branches off it and its diff will include those commits until
> #561 merges. Draft until then. Reviewable on its own: the two commits here are
> self-contained (`bstone_vdf.*` plus its tests).

## Summary

Adds a minimal reader for Valve Data Format (KeyValues) text. On its own it does nothing —
it is the groundwork for locating a Steam installation on every platform rather than only
on Windows, which follows separately.

Steam records its library folders and installed games in VDF files laid out identically on
Windows, macOS and Linux, so reading them is the portable way to find an installed game.

## Scope

Deliberately small: only what `libraryfolders.vdf` and `appmanifest_*.acf` actually use.

- Quoted and bare tokens, nested objects, `//` line comments.
- The `\\`, `\"`, `\n`, `\t` escapes. **Not optional** — Steam writes Windows paths with
  doubled separators (`"D:\\SteamLibrary"`), and a UNC library path (`\\\\NAS\\Share`)
  is silently corrupted without unescaping.
- A UTF-8 BOM is skipped. Valve's own parser does not do this, but some editors add one.

Out of scope, because these files never use them: binary VDF, `#base`/`#include`, and
platform conditionals (`[$WIN32]`).

## Two details worth calling out

**Lookup is case-insensitive**, as KeyValues is. This is not cosmetic — real files disagree
with themselves across clients (`"universe"` vs `"Universe"`), and it means one lookup finds
`libraryfolders.vdf`'s root key whether Steam wrote it as `"LibraryFolders"` (legacy) or
`"libraryfolders"` (current).

**An empty block is distinguished from a scalar.** Steam writes `"apps" {}` for a library
folder with nothing installed in it. Since `libraryfolders.vdf` maps a numbered key to a
path *string* in the legacy layout and to an *object* in the current one, a reader that
tells them apart by "does it have children" misreads an empty object as a legacy entry and
yields an empty path.

## Robustness

Malformed input is reported through the return value and never throws, and nesting is
depth-limited so a corrupt file cannot exhaust the stack. This matters because the caller
runs during start-up, before there is any UI to report an error with.

## Testing

27 tests, and because the reader is pure text-in/structure-out with no filesystem access,
they run on **every** platform and configuration in CI.

Covered: both `libraryfolders.vdf` layouts, an `appmanifest` extract, escapes including a
Windows path and a UNC path, brackets inside a quoted value (a real library lives at
`D:\Games\[Steam]`), comments, bare tokens, BOM, CRLF, case-insensitive lookup, empty
blocks, duplicate keys (first wins, as KeyValues does), and malformed input — unterminated
strings and blocks, a stray brace, a key with no value, and nesting past the depth limit.

Also validated against the real `libraryfolders.vdf` and `appmanifest_*.acf` on a live
Steam installation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
