### PR TITLE
Harden the ZIP reader against malformed archives

### DIFF
--- a/src/bstone/src/bstone_archive_file_entry_stream_inflate.cpp
+++ b/src/bstone/src/bstone_archive_file_entry_stream_inflate.cpp
@@ -101,6 +101,7 @@ int ArchiveFileInflateStream::read(void* buffer, int count)
 	BSTONE_ASSERT(count >= 0);
 	count = std::min(count, uncompressed_size_ - uncompressed_position_);
 	::Bytef* dst_bytes = static_cast<::Bytef*>(buffer);
+	bool is_stream_end = false;
 	while (count > 0)
 	{
 		if (zlib_out_cache_offset_ < zlib_stream_.total_out)
@@ -117,6 +118,11 @@ int ArchiveFileInflateStream::read(void* buffer, int count)
 		}
 		else
 		{
+			// The cache is drained. Once inflate is done it keeps reporting the end of the
+			// stream without producing anything, so an entry that decodes to less than its
+			// declared uncompressed size would spin here forever.
+			if (is_stream_end)
+				break;
 			zlib_out_cache_offset_ = 0;
 			zlib_stream_.next_out = zlib_out_cache_;
 			zlib_stream_.avail_out = zlib_out_cache_max_capacity;
@@ -143,7 +149,9 @@ int ArchiveFileInflateStream::read(void* buffer, int count)
 		switch (zlib_result)
 		{
 			case Z_OK:
+				break;
 			case Z_STREAM_END:
+				is_stream_end = true;
 				break;
 			case Z_NEED_DICT:
 			case Z_ERRNO:

--- a/src/bstone/src/bstone_archive_file_entry_stream_inflate.cpp
+++ b/src/bstone/src/bstone_archive_file_entry_stream_inflate.cpp
@@ -76,6 +76,11 @@ bool ArchiveFileInflateStream::rewind()
 		return false;
 	if (::inflateReset2(&zlib_stream_, -15) != Z_OK)
 		return false;
+	// The reset leaves the input side to the caller, so any bytes still buffered from
+	// before the rewind would be handed to the fresh inflate state as if they were the
+	// beginning of the stream.
+	zlib_stream_.next_in = zlib_in_cache_;
+	zlib_stream_.avail_in = 0;
 	compressed_position_ = compressed_begin_position_;
 	uncompressed_position_ = 0;
 	zlib_out_cache_offset_ = 0;

--- a/src/bstone/src/bstone_archive_file_entry_stream_inflate.cpp
+++ b/src/bstone/src/bstone_archive_file_entry_stream_inflate.cpp
@@ -122,7 +122,9 @@ int ArchiveFileInflateStream::read(void* buffer, int count)
 			// stream without producing anything, so an entry that decodes to less than its
 			// declared uncompressed size would spin here forever.
 			if (is_stream_end)
+			{
 				break;
+			}
 			zlib_out_cache_offset_ = 0;
 			zlib_stream_.next_out = zlib_out_cache_;
 			zlib_stream_.avail_out = zlib_out_cache_max_capacity;

--- a/src/bstone/src/bstone_archive_file_entry_stream_inflate.cpp
+++ b/src/bstone/src/bstone_archive_file_entry_stream_inflate.cpp
@@ -246,7 +246,7 @@ ArchiveFileEntryStreamUPtr make_archive_file_inflate_entry_stream(
 	BSTONE_ASSERT(archive_file_entry.compression_method == ArchiveFileCompressionMethod::deflate);
 	BSTONE_ASSERT(archive_file_entry.is_compressed);
 	BSTONE_ASSERT(archive_file_entry.compressed_size > 0);
-	BSTONE_ASSERT(archive_file_entry.uncompressed_size > 0);
+	BSTONE_ASSERT(archive_file_entry.uncompressed_size >= 0);
 	return std::make_unique<ArchiveFileInflateStream>(std::move(input_stream_uptr), archive_file_entry);
 }
 

--- a/src/bstone/src/bstone_archive_file_entry_stream_store.cpp
+++ b/src/bstone/src/bstone_archive_file_entry_stream_store.cpp
@@ -60,7 +60,9 @@ bool ArchiveFileStoreStream::rewind()
 	// The accumulator has to start over with the data, otherwise a rewind after a partial
 	// read hashes that prefix twice and the entry fails its own checksum.
 	if (is_zip_crc32_)
+	{
 		zip_crc_32_.reset();
+	}
 	return true;
 }
 

--- a/src/bstone/src/bstone_archive_file_entry_stream_store.cpp
+++ b/src/bstone/src/bstone_archive_file_entry_stream_store.cpp
@@ -57,6 +57,10 @@ bool ArchiveFileStoreStream::rewind()
 	if (!input_stream_uptr_->set_position(begin_position_))
 		return false;
 	position_ = begin_position_;
+	// The accumulator has to start over with the data, otherwise a rewind after a partial
+	// read hashes that prefix twice and the entry fails its own checksum.
+	if (is_zip_crc32_)
+		zip_crc_32_.reset();
 	return true;
 }
 

--- a/src/bstone/src/bstone_zip_archive_file.cpp
+++ b/src/bstone/src/bstone_zip_archive_file.cpp
@@ -596,7 +596,7 @@ bool ZipArchiveFile::initialize_entry_name(const CentralFileHeader& header, Arch
 void ZipArchiveFile::reserve_entries(int capacity)
 {
 	BSTONE_ASSERT(capacity >= 0);
-	BSTONE_ASSERT(capacity <= INT_MAX / sizeof(ArchiveFileEntry));
+	BSTONE_ASSERT(capacity <= static_cast<int>(INT_MAX / sizeof(ArchiveFileEntry)));
 	if (entries_capacity_ >= capacity)
 		return;
 	const int storage_size = capacity * sizeof(ArchiveFileEntry);

--- a/src/bstone/src/bstone_zip_archive_file.cpp
+++ b/src/bstone/src/bstone_zip_archive_file.cpp
@@ -174,9 +174,9 @@ private:
 	bool deserialize_central_file_header(MemoryBinaryReader& binary_reader, CentralFileHeader& header);
 	bool validate_central_file_header(const CentralFileHeader& header) const;
 	bool is_central_file_supported(const CentralFileHeader& header) const;
-	void initialize_entry_name(const CentralFileHeader& header, ArchiveFileEntry& entry);
+	bool initialize_entry_name(const CentralFileHeader& header, ArchiveFileEntry& entry);
 	void reserve_entries(int capacity);
-	void add_entry(const CentralFileHeader& header);
+	bool add_entry(const CentralFileHeader& header);
 	void reserve_names(int capacity);
 	bool read_central_dir(const EndOfCentralDirRecord& eocdr);
 	bool prepare_input_stream_for_entry(ArchiveFileInputStream& input_stream, const ArchiveFileEntry& entry) const;
@@ -371,6 +371,11 @@ bool ZipArchiveFile::validate_end_of_central_dir_record(const EndOfCentralDirRec
 		return false;
 	if (record.dir_size > max_central_dir_size)
 		return false;
+	// The entry name arena is sized by subtracting the fixed part of every promised header
+	// from the directory size. Nothing else ties the two fields together, so a directory
+	// too small to hold the entries it promises would undersize the arena.
+	if (record.dir_size < static_cast<unsigned int>(central_file_header_size * record.dir_total_entries))
+		return false;
 	if (record.dir_offset == zip64_marker_32)
 		return false;
 	return true;
@@ -550,18 +555,23 @@ bool ZipArchiveFile::is_central_file_supported(const CentralFileHeader& header) 
 	return true;
 }
 
-void ZipArchiveFile::initialize_entry_name(const CentralFileHeader& header, ArchiveFileEntry& entry)
+bool ZipArchiveFile::initialize_entry_name(const CentralFileHeader& header, ArchiveFileEntry& entry)
 {
 	BSTONE_ASSERT(header.file_name_length > 0);
 	BSTONE_ASSERT(header.file_name != nullptr);
 	const int aligned_size = align_16(header.file_name_length + 1);
-	BSTONE_ASSERT(names_capacity_ - names_size_ >= aligned_size);
+	// The arena is sized from the central directory record, so this holds for any archive
+	// the validation accepted. Keep it as a real check anyway: the names are copied
+	// verbatim out of the archive and nothing else stands between them and the heap.
+	if (names_capacity_ - names_size_ < aligned_size)
+		return false;
 	char* const entry_name = names_.get() + names_size_;
 	names_size_ += aligned_size;
 	entry.name = entry_name;
 	std::copy_n(header.file_name, header.file_name_length, entry_name);
 	entry_name[header.file_name_length] = '\0';
 	entry.name = entry_name;
+	return true;
 }
 
 void ZipArchiveFile::reserve_entries(int capacity)
@@ -576,9 +586,12 @@ void ZipArchiveFile::reserve_entries(int capacity)
 	entries_capacity_ = capacity;
 }
 
-void ZipArchiveFile::add_entry(const CentralFileHeader& header)
+bool ZipArchiveFile::add_entry(const CentralFileHeader& header)
 {
-	BSTONE_ASSERT(entries_size_ < entries_capacity_);
+	// The directory promises no more entries than were reserved, but the promise is the
+	// archive's, so keep the bound where it holds in a release build too.
+	if (entries_size_ >= entries_capacity_)
+		return false;
 	ArchiveFileEntry& entry = entries_[entries_size_];
 	// Index.
 	entry.index = entries_size_++;
@@ -603,7 +616,8 @@ void ZipArchiveFile::add_entry(const CentralFileHeader& header)
 	// Name length.
 	entry.name_length = header.file_name_length;
 	// Name.
-	initialize_entry_name(header, entry);
+	if (!initialize_entry_name(header, entry))
+		return false;
 	// Compressed size.
 	entry.compressed_size = static_cast<int>(header.compressed_size);
 	// Uncompressed size.
@@ -613,6 +627,7 @@ void ZipArchiveFile::add_entry(const CentralFileHeader& header)
 	// CRC-32 type.
 	entry.crc_32_type = ArchiveFileCrc32Type::zip;
 	entry.crc_32 = header.crc_32;
+	return true;
 }
 
 void ZipArchiveFile::reserve_names(int capacity)
@@ -644,8 +659,8 @@ bool ZipArchiveFile::read_central_dir(const EndOfCentralDirRecord& eocdr)
 			return false;
 		if (!validate_central_file_header(file_header))
 			return false;
-		if (is_central_file_supported(file_header))
-			add_entry(file_header);
+		if (is_central_file_supported(file_header) && !add_entry(file_header))
+			return false;
 	}
 	return true;
 }

--- a/src/bstone/src/bstone_zip_archive_file.cpp
+++ b/src/bstone/src/bstone_zip_archive_file.cpp
@@ -275,10 +275,6 @@ void ZipArchiveFile::deserialize_local_file_header(MemoryBinaryReader& binary_re
 	header.extra_field_length = binary_reader.read_u16_le();
 }
 
-// Everything checked here was read out of the archive, which is a file the user was given
-// and dropped into a search path. A header that fails to make sense is a rejected archive,
-// not a programming error, so none of these report themselves by asserting: a debug build
-// would abort on a file the release build merely refuses.
 bool ZipArchiveFile::validate_local_file_header(const LocalFileHeader& header, const ArchiveFileEntry& entry)
 {
 	if (header.signature != 0x04034B50U)
@@ -436,9 +432,6 @@ bool ZipArchiveFile::read_end_of_central_dir_record(EndOfCentralDirRecord& recor
 
 bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_reader, CentralFileHeader& header)
 {
-	// Truncation anywhere below is a malformed archive, which the return value already
-	// expresses; asserting would abort a debug build on a file the user merely has to be
-	// told is unusable.
 	if (!binary_reader.can_read_n(central_file_header_size))
 		return false;
 	// central file header signature   4 bytes  (0x02014B50)
@@ -586,9 +579,6 @@ bool ZipArchiveFile::initialize_entry_name(const CentralFileHeader& header, Arch
 	BSTONE_ASSERT(header.file_name_length > 0);
 	BSTONE_ASSERT(header.file_name != nullptr);
 	const int aligned_size = align_16(header.file_name_length + 1);
-	// The arena is sized from the central directory record, so this holds for any archive
-	// the validation accepted. Keep it as a real check anyway: the names are copied
-	// verbatim out of the archive and nothing else stands between them and the heap.
 	if (names_capacity_ - names_size_ < aligned_size)
 	{
 		return false;

--- a/src/bstone/src/bstone_zip_archive_file.cpp
+++ b/src/bstone/src/bstone_zip_archive_file.cpp
@@ -484,9 +484,13 @@ bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_
 	// Look up for language-related extra fields.
 	header.has_extended_language_encoding_data = false;
 	header.has_info_zip_unicode_path_extra_field = false;
+	// Bound every record by the extra field it lives in, not merely by the directory buffer.
+	// A record allowed to run past the field would leave the reader parked somewhere inside
+	// a later header and desynchronize the whole directory walk.
 	for (int extra_field_offset = 0; extra_field_offset < header.extra_field_length; )
 	{
-		if (!binary_reader.can_read_n(4))
+		const int extra_field_left = header.extra_field_length - extra_field_offset;
+		if (extra_field_left < 4)
 			return false;
 		const int extra_header_id = binary_reader.read_u16_le();
 		const int extra_header_size = binary_reader.read_u16_le();
@@ -499,7 +503,7 @@ bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_
 				header.has_info_zip_unicode_path_extra_field = true;
 				break;
 		}
-		if (!binary_reader.can_read_n(extra_header_size))
+		if (extra_header_size > extra_field_left - 4)
 			return false;
 		binary_reader.skip(extra_header_size);
 		extra_field_offset += 4 + extra_header_size;

--- a/src/bstone/src/bstone_zip_archive_file.cpp
+++ b/src/bstone/src/bstone_zip_archive_file.cpp
@@ -550,6 +550,21 @@ bool ZipArchiveFile::is_central_file_supported(const CentralFileHeader& header) 
 	{
 		return false;
 	}
+	// A stored entry occupies exactly as many bytes as it yields. The entry stream takes
+	// its extent from the uncompressed size alone, so a header claiming a bigger one would
+	// hand out whatever follows the entry in the archive.
+	if (header.compression_method == compression_method_store &&
+		header.compressed_size != header.uncompressed_size)
+	{
+		return false;
+	}
+	// The inflate stream is built for an entry that has something to decode on both sides,
+	// which until now was only a precondition its factory asserted.
+	if (header.compression_method == compression_method_deflate &&
+		(header.compressed_size == 0 || header.uncompressed_size == 0))
+	{
+		return false;
+	}
 	if (header.file_name_length == 0)
 		return false;
 	if (header.local_header_offset == zip64_marker_32)

--- a/src/bstone/src/bstone_zip_archive_file.cpp
+++ b/src/bstone/src/bstone_zip_archive_file.cpp
@@ -558,10 +558,11 @@ bool ZipArchiveFile::is_central_file_supported(const CentralFileHeader& header) 
 	{
 		return false;
 	}
-	// The inflate stream is built for an entry that has something to decode on both sides,
-	// which until now was only a precondition its factory asserted.
+	// A deflate stream is never empty - even zero bytes of input deflate into a
+	// two-byte stream, which is how zipfile and friends store an empty member -
+	// so only an entry with nothing to decode is malformed.
 	if (header.compression_method == compression_method_deflate &&
-		(header.compressed_size == 0 || header.uncompressed_size == 0))
+		header.compressed_size == 0)
 	{
 		return false;
 	}

--- a/src/bstone/src/bstone_zip_archive_file.cpp
+++ b/src/bstone/src/bstone_zip_archive_file.cpp
@@ -275,29 +275,26 @@ void ZipArchiveFile::deserialize_local_file_header(MemoryBinaryReader& binary_re
 	header.extra_field_length = binary_reader.read_u16_le();
 }
 
+// Everything checked here was read out of the archive, which is a file the user was given
+// and dropped into a search path. A header that fails to make sense is a rejected archive,
+// not a programming error, so none of these report themselves by asserting: a debug build
+// would abort on a file the release build merely refuses.
 bool ZipArchiveFile::validate_local_file_header(const LocalFileHeader& header, const ArchiveFileEntry& entry)
 {
 	if (header.signature != 0x04034B50U)
-	{
-		BSTONE_ASSERT(false && "Invalid signature.");
 		return false;
-	}
 	if (((header.flags & file_encrypted_flag) != 0) ||
 		((header.flags & patched_data_flag) != 0) ||
 		((header.flags & strong_encryption_flag) != 0) ||
 		((header.flags & dir_encrypted_flag) != 0))
 	{
-		BSTONE_ASSERT(false && "Encryption/Patched data.");
 		return false;
 	}
 	const bool is_utf8 = (header.flags & language_flag) != 0;
 	const ArchiveFileLanguageEncoding language_encoding =
 		is_utf8 ? ArchiveFileLanguageEncoding::utf8 : ArchiveFileLanguageEncoding::cp437;
 	if (language_encoding != entry.language_encoding)
-	{
-		BSTONE_ASSERT(false && "Name encoding mismatch.");
 		return false;
-	}
 	ArchiveFileCompressionMethod compression_method;
 	switch (header.compression_method)
 	{
@@ -312,34 +309,19 @@ bool ZipArchiveFile::validate_local_file_header(const LocalFileHeader& header, c
 			break;
 	}
 	if (compression_method != entry.compression_method)
-	{
-		BSTONE_ASSERT(false && "Compression method mismatch.");
 		return false;
-	}
 	const bool has_data_descriptor = (header.flags & data_descriptor_flag) != 0;
 	if (!has_data_descriptor)
 	{
 		if (header.crc_32 != entry.crc_32)
-		{
-			BSTONE_ASSERT(false && "CRC-32 mismatch.");
 			return false;
-		}
 		if (header.compressed_size != static_cast<unsigned int>(entry.compressed_size))
-		{
-			BSTONE_ASSERT(false && "Compressed size mismatch.");
 			return false;
-		}
 		if (header.uncompressed_size != static_cast<unsigned int>(entry.uncompressed_size))
-		{
-			BSTONE_ASSERT(false && "Uncompressed size mismatch.");
 			return false;
-		}
 	}
 	if (header.file_name_length != entry.name_length)
-	{
-		BSTONE_ASSERT(false && "Filename length mismatch.");
 		return false;
-	}
 	return true;
 }
 
@@ -373,46 +355,24 @@ void ZipArchiveFile::deserialize_end_of_central_dir_record(MemoryBinaryReader& b
 
 bool ZipArchiveFile::validate_end_of_central_dir_record(const EndOfCentralDirRecord& record) const
 {
+	// A ZIP64 archive, a multi-disk one and a self-contradicting one are all simply
+	// unsupported input, so they are refused the same way an unreadable file would be.
 	if (record.this_disk_number != 0)
-	{
-		BSTONE_ASSERT(false && "Expected zero number of this disk.");
 		return false;
-	}
 	if (record.dir_disk_number != 0)
-	{
-		BSTONE_ASSERT(false && "Expected zero number of disk with the start of central directory.");
 		return false;
-	}
 	if (record.this_total_entries == zip64_marker_16)
-	{
-		BSTONE_ASSERT(false && "ZIP64 not supported.");
 		return false;
-	}
 	if (record.dir_total_entries == zip64_marker_16)
-	{
-		BSTONE_ASSERT(false && "ZIP64 not supported.");
 		return false;
-	}
 	if (record.this_total_entries != record.dir_total_entries)
-	{
-		BSTONE_ASSERT(false && "Total entries mismatch.");
 		return false;
-	}
 	if (record.dir_size == zip64_marker_32)
-	{
-		BSTONE_ASSERT(false && "ZIP64 not supported.");
 		return false;
-	}
 	if (record.dir_size > max_central_dir_size)
-	{
-		BSTONE_ASSERT(false && "Central directory too big.");
 		return false;
-	}
 	if (record.dir_offset == zip64_marker_32)
-	{
-		BSTONE_ASSERT(false && "ZIP64 not supported.");
 		return false;
-	}
 	return true;
 }
 
@@ -420,15 +380,9 @@ bool ZipArchiveFile::read_end_of_central_dir_record(EndOfCentralDirRecord& recor
 {
 	const long long archive_size = input_stream_->get_size();
 	if (archive_size < 0)
-	{
-		BSTONE_ASSERT(false && "Failed to get the archive size.");
 		return false;
-	}
 	if (archive_size < end_of_central_dir_record_size)
-	{
-		BSTONE_ASSERT(false && "End of central directory record too small.");
 		return false;
-	}
 	constexpr int max_comment_length = 0xFFFF;
 	constexpr int history_size = end_of_central_dir_record_size - 1;
 	constexpr long long max_scan_size = end_of_central_dir_record_size + max_comment_length;
@@ -475,11 +429,11 @@ bool ZipArchiveFile::read_end_of_central_dir_record(EndOfCentralDirRecord& recor
 
 bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_reader, CentralFileHeader& header)
 {
+	// Truncation anywhere below is a malformed archive, which the return value already
+	// expresses; asserting would abort a debug build on a file the user merely has to be
+	// told is unusable.
 	if (!binary_reader.can_read_n(central_file_header_size))
-	{
-		BSTONE_ASSERT(false && "Central file header too small.");
 		return false;
-	}
 	// central file header signature   4 bytes  (0x02014B50)
 	header.signature                = binary_reader.read_u32_le();
 	// version made by                 2 bytes
@@ -516,28 +470,19 @@ bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_
 	header.local_header_offset      = binary_reader.read_u32_le();
 	// file name (variable size)
 	if (!binary_reader.can_read_n(header.file_name_length))
-	{
-		BSTONE_ASSERT(false && "Truncated file name.");
 		return false;
-	}
 	header.file_name = static_cast<const char*>(binary_reader.get_current_data());
 	binary_reader.skip(header.file_name_length);
 	// extra field (variable size)
 	if (!binary_reader.can_read_n(header.extra_field_length))
-	{
-		BSTONE_ASSERT(false && "Truncated extra field.");
 		return false;
-	}
 	// Look up for language-related extra fields.
 	header.has_extended_language_encoding_data = false;
 	header.has_info_zip_unicode_path_extra_field = false;
 	for (int extra_field_offset = 0; extra_field_offset < header.extra_field_length; )
 	{
 		if (!binary_reader.can_read_n(4))
-		{
-			BSTONE_ASSERT(false && "Truncated extra record.");
 			return false;
-		}
 		const int extra_header_id = binary_reader.read_u16_le();
 		const int extra_header_size = binary_reader.read_u16_le();
 		switch (extra_header_id)
@@ -550,19 +495,13 @@ bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_
 				break;
 		}
 		if (!binary_reader.can_read_n(extra_header_size))
-		{
-			BSTONE_ASSERT(false && "Extra record underflow.");
 			return false;
-		}
 		binary_reader.skip(extra_header_size);
 		extra_field_offset += 4 + extra_header_size;
 	}
 	// file comment (variable size)
 	if (!binary_reader.can_read_n(header.file_comment_length))
-	{
-		BSTONE_ASSERT(false && "Truncated file comment.");
 		return false;
-	}
 	binary_reader.skip(header.file_comment_length);
 	//
 	return true;
@@ -571,15 +510,9 @@ bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_
 bool ZipArchiveFile::validate_central_file_header(const CentralFileHeader& header) const
 {
 	if (header.signature != 0x02014B50U)
-	{
-		BSTONE_ASSERT(false && "Invalid signature of central file header.");
 		return false;
-	}
 	if (header.disk_number_start != 0)
-	{
-		BSTONE_ASSERT(false && "Expected zero disk number start of central file header.");
 		return false;
-	}
 	return true;
 }
 
@@ -697,16 +630,10 @@ bool ZipArchiveFile::read_central_dir(const EndOfCentralDirRecord& eocdr)
 	BufferUPtr dir_buffer{::operator new(std::size_t{eocdr.dir_size})};
 	reserve_entries(eocdr.dir_total_entries);
 	if (!input_stream_->set_position(eocdr.dir_offset))
-	{
-		BSTONE_ASSERT(false && "Failed to position at the beginning of the central directory.");
 		return false;
-	}
 	MemoryBinaryReader dir_binary_reader{dir_buffer.get(), static_cast<int>(eocdr.dir_size)};
 	if (!input_stream_->read_exactly(dir_buffer.get(), static_cast<int>(eocdr.dir_size)))
-	{
-		BSTONE_ASSERT(false && "Failed to read the central directory.");
 		return false;
-	}
 	const int names_capacity = static_cast<int>(eocdr.dir_size) -
 		((central_file_header_size - 16 /* (alignment-1)+NULL */) * eocdr.dir_total_entries);
 	reserve_names(names_capacity);

--- a/src/bstone/src/bstone_zip_archive_file.cpp
+++ b/src/bstone/src/bstone_zip_archive_file.cpp
@@ -375,7 +375,9 @@ bool ZipArchiveFile::validate_end_of_central_dir_record(const EndOfCentralDirRec
 	// from the directory size. Nothing else ties the two fields together, so a directory
 	// too small to hold the entries it promises would undersize the arena.
 	if (record.dir_size < static_cast<unsigned int>(central_file_header_size * record.dir_total_entries))
+	{
 		return false;
+	}
 	if (record.dir_offset == zip64_marker_32)
 		return false;
 	return true;
@@ -491,7 +493,9 @@ bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_
 	{
 		const int extra_field_left = header.extra_field_length - extra_field_offset;
 		if (extra_field_left < 4)
+		{
 			return false;
+		}
 		const int extra_header_id = binary_reader.read_u16_le();
 		const int extra_header_size = binary_reader.read_u16_le();
 		switch (extra_header_id)
@@ -504,7 +508,9 @@ bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_
 				break;
 		}
 		if (extra_header_size > extra_field_left - 4)
+		{
 			return false;
+		}
 		binary_reader.skip(extra_header_size);
 		extra_field_offset += 4 + extra_header_size;
 	}
@@ -584,7 +590,9 @@ bool ZipArchiveFile::initialize_entry_name(const CentralFileHeader& header, Arch
 	// the validation accepted. Keep it as a real check anyway: the names are copied
 	// verbatim out of the archive and nothing else stands between them and the heap.
 	if (names_capacity_ - names_size_ < aligned_size)
+	{
 		return false;
+	}
 	char* const entry_name = names_.get() + names_size_;
 	names_size_ += aligned_size;
 	entry.name = entry_name;
@@ -611,7 +619,9 @@ bool ZipArchiveFile::add_entry(const CentralFileHeader& header)
 	// The directory promises no more entries than were reserved, but the promise is the
 	// archive's, so keep the bound where it holds in a release build too.
 	if (entries_size_ >= entries_capacity_)
+	{
 		return false;
+	}
 	ArchiveFileEntry& entry = entries_[entries_size_];
 	// Index.
 	entry.index = entries_size_++;
@@ -637,7 +647,9 @@ bool ZipArchiveFile::add_entry(const CentralFileHeader& header)
 	entry.name_length = header.file_name_length;
 	// Name.
 	if (!initialize_entry_name(header, entry))
+	{
 		return false;
+	}
 	// Compressed size.
 	entry.compressed_size = static_cast<int>(header.compressed_size);
 	// Uncompressed size.
@@ -680,7 +692,9 @@ bool ZipArchiveFile::read_central_dir(const EndOfCentralDirRecord& eocdr)
 		if (!validate_central_file_header(file_header))
 			return false;
 		if (is_central_file_supported(file_header) && !add_entry(file_header))
+		{
 			return false;
+		}
 	}
 	return true;
 }

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(bstone_tests
 		bstone::lib::dr_flac
 		bstone::lib::sdl
 		bstone::lib::stb_vorbis
+		bstone::lib::zlib
 )
 
 target_sources(bstone_tests
@@ -93,6 +94,19 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_steam_manifest.h
 		../../../bstone/src/bstone_vdf.cpp
 		../../../bstone/src/bstone_vdf.h
+		../../../bstone/src/bstone_memory_binary_reader.cpp
+		../../../bstone/src/bstone_memory_binary_reader.h
+		../../../bstone/src/bstone_archive_file.h
+		../../../bstone/src/bstone_archive_file_entry_stream.h
+		../../../bstone/src/bstone_archive_file_entry_stream_inflate.cpp
+		../../../bstone/src/bstone_archive_file_entry_stream_store.cpp
+		../../../bstone/src/bstone_archive_file_input_stream.h
+		../../../bstone/src/bstone_archive_file_input_stream_file.cpp
+		../../../bstone/src/bstone_archive_file_input_stream_memory.cpp
+		../../../bstone/src/bstone_zip_archive_file.cpp
+		../../../bstone/src/bstone_zip_archive_file.h
+		../../../bstone/src/bstone_zip_archive_file_crc_32.cpp
+		../../../bstone/src/bstone_zip_archive_file_crc_32.h
 	PRIVATE
 		src/bstone_tests_ascii.cpp
 		src/bstone_tests_char_conv.cpp
@@ -116,6 +130,7 @@ target_sources(bstone_tests
 		src/bstone_tests_four_cc.cpp
 		src/bstone_tests_steam_manifest.cpp
 		src/bstone_tests_vdf.cpp
+		src/bstone_tests_zip_archive_file.cpp
 	PRIVATE
 		src/bstone_tester.cpp
 		src/bstone_tester.h

--- a/src/tests/src/tests/src/bstone_tests_zip_archive_file.cpp
+++ b/src/tests/src/tests/src/bstone_tests_zip_archive_file.cpp
@@ -394,6 +394,32 @@ void test_g7pz9khn3bwr1amx()
 
 // ==========================================================================
 
+// ArchiveFileEntryStreamUPtr open_entry_stream(int) const
+// A zero-byte member stored with the deflate method, the way Python's zipfile
+// and .NET write one: method 8, two compressed bytes (the empty deflate
+// stream), no uncompressed bytes, a zero CRC.
+void test_e2vm8qk4xjw1zryd()
+{
+	const auto data = make_pattern_bytes(64);
+	const auto zip = make_test_zip({
+		make_stored_entry("assets/one.txt", data),
+		make_deflated_entry("assets/empty.txt", Bytes{})});
+	const auto archive_file = bstone::make_zip_archive_file();
+	if (!open_test_zip(*archive_file, zip))
+		tester.fail("Failed to open the archive.");
+	if (archive_file->get_entry_count() != 2)
+		tester.fail("Missing the zero-byte entry.");
+	tester.check(
+		archive_file->get_entry(1).uncompressed_size == 0 &&
+		archive_file->get_entry(1).is_compressed);
+	const auto stream = archive_file->open_entry_stream(1);
+	if (stream == nullptr)
+		tester.fail("Failed to open the entry stream.");
+	auto actual_data = Bytes(16);
+	const auto read_size = stream->read(actual_data.data(), static_cast<int>(actual_data.size()));
+	tester.check(stream->get_size() == 0 && read_size == 0);
+}
+
 class Registrator
 {
 public:
@@ -422,6 +448,7 @@ private:
 		tester.register_test("ZipArchiveFile#n1cb6mfxr8u3ypgo", test_n1cb6mfxr8u3ypgo);
 		tester.register_test("ZipArchiveFile#y4jq0ei5tsl7dvzc", test_y4jq0ei5tsl7dvzc);
 		tester.register_test("ZipArchiveFile#g7pz9khn3bwr1amx", test_g7pz9khn3bwr1amx);
+		tester.register_test("ZipArchiveFile#e2vm8qk4xjw1zryd", test_e2vm8qk4xjw1zryd);
 	}
 };
 

--- a/src/tests/src/tests/src/bstone_tests_zip_archive_file.cpp
+++ b/src/tests/src/tests/src/bstone_tests_zip_archive_file.cpp
@@ -46,7 +46,9 @@ void add_bytes(Bytes& bytes, const Bytes& value)
 void add_name(Bytes& bytes, const std::string& name)
 {
 	for (const char ch : name)
+	{
 		bytes.push_back(static_cast<unsigned char>(ch));
+	}
 }
 
 // An entry as it will be written out. The sizes are separate from the data on purpose:
@@ -142,7 +144,9 @@ Bytes make_pattern_bytes(int size)
 {
 	auto bytes = Bytes(static_cast<std::size_t>(size));
 	for (int i = 0; i < size; ++i)
+	{
 		bytes[static_cast<std::size_t>(i)] = static_cast<unsigned char>(i & 0x0F);
+	}
 	return bytes;
 }
 
@@ -163,7 +167,9 @@ Bytes deflate_bytes(const Bytes& src)
 	stream.zalloc = zlib_alloc_func;
 	stream.zfree = zlib_free_func;
 	if (::deflateInit2(&stream, Z_BEST_COMPRESSION, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY) != Z_OK)
+	{
 		return Bytes{};
+	}
 	auto dst = Bytes(src.size() + 1024);
 	stream.next_in = src.data();
 	stream.avail_in = static_cast<::uInt>(src.size());
@@ -173,7 +179,9 @@ Bytes deflate_bytes(const Bytes& src)
 	const auto dst_size = static_cast<std::size_t>(stream.total_out);
 	static_cast<void>(::deflateEnd(&stream));
 	if (deflate_result != Z_STREAM_END)
+	{
 		return Bytes{};
+	}
 	dst.resize(dst_size);
 	return dst;
 }
@@ -303,10 +311,14 @@ void test_c5ho3jw8qylb2unx()
 	const auto zip = make_test_zip({make_stored_entry("one.txt", data)});
 	const auto archive_file = bstone::make_zip_archive_file();
 	if (!open_test_zip(*archive_file, zip))
+	{
 		tester.fail("Failed to open the archive.");
+	}
 	const auto stream = archive_file->open_entry_stream(0);
 	if (stream == nullptr)
+	{
 		tester.fail("Failed to open the entry stream.");
+	}
 	auto actual_data = Bytes(data.size());
 	const auto read_size = stream->read(actual_data.data(), static_cast<int>(actual_data.size()));
 	tester.check(stream->get_size() == 64 && read_size == 64 && actual_data == data);
@@ -320,10 +332,14 @@ void test_w2ke7sza4vd9tlq6()
 	const auto zip = make_test_zip({make_stored_entry("one.txt", data)});
 	const auto archive_file = bstone::make_zip_archive_file();
 	if (!open_test_zip(*archive_file, zip))
+	{
 		tester.fail("Failed to open the archive.");
+	}
 	const auto stream = archive_file->open_entry_stream(0);
 	if (stream == nullptr)
+	{
 		tester.fail("Failed to open the entry stream.");
+	}
 	auto partial_data = Bytes(16);
 	const auto partial_read_size = stream->read(partial_data.data(), static_cast<int>(partial_data.size()));
 	const auto is_rewound = stream->rewind();
@@ -340,10 +356,14 @@ void test_n1cb6mfxr8u3ypgo()
 	const auto zip = make_test_zip({make_deflated_entry("one.txt", data)});
 	const auto archive_file = bstone::make_zip_archive_file();
 	if (!open_test_zip(*archive_file, zip))
+	{
 		tester.fail("Failed to open the archive.");
+	}
 	const auto stream = archive_file->open_entry_stream(0);
 	if (stream == nullptr)
+	{
 		tester.fail("Failed to open the entry stream.");
+	}
 	auto actual_data = Bytes(data.size());
 	const auto read_size = stream->read(actual_data.data(), static_cast<int>(actual_data.size()));
 	tester.check(stream->get_size() == 4096 && read_size == 4096 && actual_data == data);
@@ -358,10 +378,14 @@ void test_y4jq0ei5tsl7dvzc()
 	const auto zip = make_test_zip({make_deflated_entry("one.txt", data)});
 	const auto archive_file = bstone::make_zip_archive_file();
 	if (!open_test_zip(*archive_file, zip))
+	{
 		tester.fail("Failed to open the archive.");
+	}
 	const auto stream = archive_file->open_entry_stream(0);
 	if (stream == nullptr)
+	{
 		tester.fail("Failed to open the entry stream.");
+	}
 	auto partial_data = Bytes(16);
 	const auto partial_read_size = stream->read(partial_data.data(), static_cast<int>(partial_data.size()));
 	const auto is_rewound = stream->rewind();
@@ -380,10 +404,14 @@ void test_g7pz9khn3bwr1amx()
 	const auto zip = make_test_zip({entry});
 	const auto archive_file = bstone::make_zip_archive_file();
 	if (!open_test_zip(*archive_file, zip))
+	{
 		tester.fail("Failed to open the archive.");
+	}
 	const auto stream = archive_file->open_entry_stream(0);
 	if (stream == nullptr)
+	{
 		tester.fail("Failed to open the entry stream.");
+	}
 	auto actual_data = Bytes(100000);
 	const auto read_size = stream->read(actual_data.data(), static_cast<int>(actual_data.size()));
 	auto extra_byte = Bytes(1);
@@ -406,15 +434,21 @@ void test_e2vm8qk4xjw1zryd()
 		make_deflated_entry("assets/empty.txt", Bytes{})});
 	const auto archive_file = bstone::make_zip_archive_file();
 	if (!open_test_zip(*archive_file, zip))
+	{
 		tester.fail("Failed to open the archive.");
+	}
 	if (archive_file->get_entry_count() != 2)
+	{
 		tester.fail("Missing the zero-byte entry.");
+	}
 	tester.check(
 		archive_file->get_entry(1).uncompressed_size == 0 &&
 		archive_file->get_entry(1).is_compressed);
 	const auto stream = archive_file->open_entry_stream(1);
 	if (stream == nullptr)
+	{
 		tester.fail("Failed to open the entry stream.");
+	}
 	auto actual_data = Bytes(16);
 	const auto read_size = stream->read(actual_data.data(), static_cast<int>(actual_data.size()));
 	tester.check(stream->get_size() == 0 && read_size == 0);

--- a/src/tests/src/tests/src/bstone_tests_zip_archive_file.cpp
+++ b/src/tests/src/tests/src/bstone_tests_zip_archive_file.cpp
@@ -1,0 +1,430 @@
+#include <cstddef>
+
+#include <new>
+#include <string>
+#include <vector>
+
+#include "zlib.h"
+
+#include "bstone_archive_file.h"
+#include "bstone_tester.h"
+#include "bstone_zip_archive_file.h"
+#include "bstone_zip_archive_file_crc_32.h"
+
+namespace {
+
+auto tester = bstone::Tester{};
+
+// ==========================================================================
+
+using Bytes = std::vector<unsigned char>;
+
+constexpr auto local_file_header_signature = 0x04034B50U;
+constexpr auto central_file_header_signature = 0x02014B50U;
+constexpr auto end_of_central_dir_record_signature = 0x06054B50U;
+
+constexpr auto compression_method_store = 0U;
+constexpr auto compression_method_deflate = 8U;
+
+void add_u16(Bytes& bytes, unsigned int value)
+{
+	bytes.push_back(static_cast<unsigned char>(value & 0xFFU));
+	bytes.push_back(static_cast<unsigned char>((value >> 8) & 0xFFU));
+}
+
+void add_u32(Bytes& bytes, unsigned int value)
+{
+	add_u16(bytes, value & 0xFFFFU);
+	add_u16(bytes, (value >> 16) & 0xFFFFU);
+}
+
+void add_bytes(Bytes& bytes, const Bytes& value)
+{
+	bytes.insert(bytes.end(), value.cbegin(), value.cend());
+}
+
+void add_name(Bytes& bytes, const std::string& name)
+{
+	for (const char ch : name)
+		bytes.push_back(static_cast<unsigned char>(ch));
+}
+
+// An entry as it will be written out. The sizes are separate from the data on purpose:
+// a malformed archive is one where they disagree.
+struct TestZipEntry
+{
+	std::string name{};
+	unsigned int compression_method{};
+	unsigned int crc_32{};
+	unsigned int compressed_size{};
+	unsigned int uncompressed_size{};
+	Bytes data{};
+	Bytes extra_field{}; // Central header only.
+};
+
+// Assembles a complete archive. A non-negative "dir_total_entries" overrides the count the
+// end of central directory record promises, which is otherwise the real one.
+Bytes make_test_zip(const std::vector<TestZipEntry>& entries, int dir_total_entries = -1)
+{
+	auto bytes = Bytes{};
+	auto local_header_offsets = std::vector<unsigned int>{};
+	for (const TestZipEntry& entry : entries)
+	{
+		local_header_offsets.push_back(static_cast<unsigned int>(bytes.size()));
+		add_u32(bytes, local_file_header_signature);
+		add_u16(bytes, 20); // version needed
+		add_u16(bytes, 0); // flags
+		add_u16(bytes, entry.compression_method);
+		add_u16(bytes, 0); // time
+		add_u16(bytes, 0); // date
+		add_u32(bytes, entry.crc_32);
+		add_u32(bytes, entry.compressed_size);
+		add_u32(bytes, entry.uncompressed_size);
+		add_u16(bytes, static_cast<unsigned int>(entry.name.size()));
+		add_u16(bytes, 0); // extra field length
+		add_name(bytes, entry.name);
+		add_bytes(bytes, entry.data);
+	}
+	const auto dir_offset = static_cast<unsigned int>(bytes.size());
+	for (std::size_t i = 0; i < entries.size(); ++i)
+	{
+		const TestZipEntry& entry = entries[i];
+		add_u32(bytes, central_file_header_signature);
+		add_u16(bytes, 20); // version made by
+		add_u16(bytes, 20); // version needed
+		add_u16(bytes, 0); // flags
+		add_u16(bytes, entry.compression_method);
+		add_u16(bytes, 0); // time
+		add_u16(bytes, 0); // date
+		add_u32(bytes, entry.crc_32);
+		add_u32(bytes, entry.compressed_size);
+		add_u32(bytes, entry.uncompressed_size);
+		add_u16(bytes, static_cast<unsigned int>(entry.name.size()));
+		add_u16(bytes, static_cast<unsigned int>(entry.extra_field.size()));
+		add_u16(bytes, 0); // file comment length
+		add_u16(bytes, 0); // disk number start
+		add_u16(bytes, 0); // internal attributes
+		add_u32(bytes, 0); // external attributes
+		add_u32(bytes, local_header_offsets[i]);
+		add_name(bytes, entry.name);
+		add_bytes(bytes, entry.extra_field);
+	}
+	const auto dir_size = static_cast<unsigned int>(bytes.size()) - dir_offset;
+	const auto total_entries = dir_total_entries >= 0
+		? static_cast<unsigned int>(dir_total_entries)
+		: static_cast<unsigned int>(entries.size());
+	add_u32(bytes, end_of_central_dir_record_signature);
+	add_u16(bytes, 0); // this disk number
+	add_u16(bytes, 0); // dir disk number
+	add_u16(bytes, total_entries);
+	add_u16(bytes, total_entries);
+	add_u32(bytes, dir_size);
+	add_u32(bytes, dir_offset);
+	add_u16(bytes, 0); // comment length
+	return bytes;
+}
+
+bool open_test_zip(bstone::ArchiveFile& archive_file, const Bytes& bytes)
+{
+	return archive_file.open_memory(bytes.data(), static_cast<int>(bytes.size()));
+}
+
+unsigned int zip_crc_32(const Bytes& bytes)
+{
+	auto crc_32 = bstone::ZipArchiveFileCrc32{};
+	crc_32.reset();
+	crc_32.update(bytes.data(), static_cast<int>(bytes.size()));
+	crc_32.finish();
+	return crc_32.get_value();
+}
+
+Bytes make_pattern_bytes(int size)
+{
+	auto bytes = Bytes(static_cast<std::size_t>(size));
+	for (int i = 0; i < size; ++i)
+		bytes[static_cast<std::size_t>(i)] = static_cast<unsigned char>(i & 0x0F);
+	return bytes;
+}
+
+// The bundled zlib is built with Z_SOLO, so it has no allocator of its own.
+::voidpf zlib_alloc_func(::voidpf, ::uInt items, ::uInt size)
+{
+	return ::operator new(std::size_t{items} * size, std::nothrow);
+}
+
+void zlib_free_func(::voidpf, ::voidpf address)
+{
+	::operator delete(address);
+}
+
+Bytes deflate_bytes(const Bytes& src)
+{
+	auto stream = ::z_stream{};
+	stream.zalloc = zlib_alloc_func;
+	stream.zfree = zlib_free_func;
+	if (::deflateInit2(&stream, Z_BEST_COMPRESSION, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY) != Z_OK)
+		return Bytes{};
+	auto dst = Bytes(src.size() + 1024);
+	stream.next_in = src.data();
+	stream.avail_in = static_cast<::uInt>(src.size());
+	stream.next_out = dst.data();
+	stream.avail_out = static_cast<::uInt>(dst.size());
+	const int deflate_result = ::deflate(&stream, Z_FINISH);
+	const auto dst_size = static_cast<std::size_t>(stream.total_out);
+	static_cast<void>(::deflateEnd(&stream));
+	if (deflate_result != Z_STREAM_END)
+		return Bytes{};
+	dst.resize(dst_size);
+	return dst;
+}
+
+TestZipEntry make_stored_entry(const std::string& name, const Bytes& data)
+{
+	auto entry = TestZipEntry{};
+	entry.name = name;
+	entry.compression_method = compression_method_store;
+	entry.crc_32 = zip_crc_32(data);
+	entry.compressed_size = static_cast<unsigned int>(data.size());
+	entry.uncompressed_size = static_cast<unsigned int>(data.size());
+	entry.data = data;
+	return entry;
+}
+
+TestZipEntry make_deflated_entry(const std::string& name, const Bytes& data)
+{
+	auto entry = TestZipEntry{};
+	entry.name = name;
+	entry.compression_method = compression_method_deflate;
+	entry.crc_32 = zip_crc_32(data);
+	entry.data = deflate_bytes(data);
+	entry.compressed_size = static_cast<unsigned int>(entry.data.size());
+	entry.uncompressed_size = static_cast<unsigned int>(data.size());
+	return entry;
+}
+
+// ==========================================================================
+
+// bool open_memory(const void*, int)
+// A well-formed archive with one stored entry.
+void test_q7m3xk1p9wz0aebt()
+{
+	const auto data = make_pattern_bytes(64);
+	const auto zip = make_test_zip({make_stored_entry("assets/one.txt", data)});
+	const auto archive_file = bstone::make_zip_archive_file();
+	const auto is_open = open_test_zip(*archive_file, zip);
+	tester.check(
+		is_open &&
+		archive_file->get_entry_count() == 1 &&
+		std::string{archive_file->get_entry(0).name} == "assets/one.txt" &&
+		archive_file->get_entry(0).name_length == 14 &&
+		archive_file->get_entry(0).uncompressed_size == 64 &&
+		!archive_file->get_entry(0).is_compressed);
+}
+
+// bool open_memory(const void*, int)
+// The directory promises more entries than it has room for.
+void test_h4nv82rjc6ylsq5d()
+{
+	const auto data = make_pattern_bytes(64);
+	const auto zip = make_test_zip({make_stored_entry("assets/one.txt", data)}, 2);
+	const auto archive_file = bstone::make_zip_archive_file();
+	tester.check(!open_test_zip(*archive_file, zip));
+}
+
+// bool open_memory(const void*, int)
+// The directory promises the largest entry count a non-ZIP64 record can hold.
+void test_z0f9tk3mwq7bxr14()
+{
+	const auto data = make_pattern_bytes(64);
+	const auto zip = make_test_zip({make_stored_entry("assets/one.txt", data)}, 0xFFFE);
+	const auto archive_file = bstone::make_zip_archive_file();
+	tester.check(!open_test_zip(*archive_file, zip));
+}
+
+// bool open_memory(const void*, int)
+// The directory is big enough for the promised entries yet its names do not fit the arena
+// those entries leave room for.
+void test_p6ay5dn8hjv2ceu0()
+{
+	const auto data = make_pattern_bytes(16);
+	const auto name = std::string(64, 'n');
+	const auto zip = make_test_zip({make_stored_entry(name, data)}, 2);
+	const auto archive_file = bstone::make_zip_archive_file();
+	tester.check(!open_test_zip(*archive_file, zip));
+}
+
+// bool open_memory(const void*, int)
+// An extra field holding one well-formed record.
+void test_r3wq7lz1o9skmv6t()
+{
+	const auto data = make_pattern_bytes(16);
+	auto entry = make_stored_entry("one.txt", data);
+	entry.extra_field = Bytes{0x0A, 0x00, 0x04, 0x00, 0x01, 0x02, 0x03, 0x04};
+	const auto zip = make_test_zip({entry});
+	const auto archive_file = bstone::make_zip_archive_file();
+	const auto is_open = open_test_zip(*archive_file, zip);
+	tester.check(is_open && archive_file->get_entry_count() == 1);
+}
+
+// bool open_memory(const void*, int)
+// An extra record whose declared size runs past the extra field it lives in. It stops just
+// inside the directory buffer, on the last byte of the header that follows.
+void test_b8xu4gyc2n5jhwq3()
+{
+	const auto data = make_pattern_bytes(16);
+	auto first_entry = make_stored_entry("a.txt", data);
+	first_entry.extra_field = Bytes{0x0A, 0x00, 0x37, 0x00, 0x01, 0x02, 0x03, 0x04};
+	const auto second_entry = make_stored_entry("b.txt", data);
+	const auto zip = make_test_zip({first_entry, second_entry}, 1);
+	const auto archive_file = bstone::make_zip_archive_file();
+	tester.check(!open_test_zip(*archive_file, zip));
+}
+
+// bool open_memory(const void*, int)
+// A stored entry whose two sizes disagree.
+void test_k9td1rvp7f0mzsae()
+{
+	const auto data = make_pattern_bytes(64);
+	auto entry = make_stored_entry("one.txt", data);
+	entry.compressed_size = 0;
+	const auto zip = make_test_zip({entry});
+	const auto archive_file = bstone::make_zip_archive_file();
+	const auto is_open = open_test_zip(*archive_file, zip);
+	tester.check(is_open && archive_file->get_entry_count() == 0);
+}
+
+// ==========================================================================
+
+// ArchiveFileEntryStreamUPtr open_entry_stream(int) const
+// A stored entry reads back byte for byte.
+void test_c5ho3jw8qylb2unx()
+{
+	const auto data = make_pattern_bytes(64);
+	const auto zip = make_test_zip({make_stored_entry("one.txt", data)});
+	const auto archive_file = bstone::make_zip_archive_file();
+	if (!open_test_zip(*archive_file, zip))
+		tester.fail("Failed to open the archive.");
+	const auto stream = archive_file->open_entry_stream(0);
+	if (stream == nullptr)
+		tester.fail("Failed to open the entry stream.");
+	auto actual_data = Bytes(data.size());
+	const auto read_size = stream->read(actual_data.data(), static_cast<int>(actual_data.size()));
+	tester.check(stream->get_size() == 64 && read_size == 64 && actual_data == data);
+}
+
+// ArchiveFileEntryStreamUPtr open_entry_stream(int) const
+// A stored entry rewound after a partial read hashes only the second pass.
+void test_w2ke7sza4vd9tlq6()
+{
+	const auto data = make_pattern_bytes(64);
+	const auto zip = make_test_zip({make_stored_entry("one.txt", data)});
+	const auto archive_file = bstone::make_zip_archive_file();
+	if (!open_test_zip(*archive_file, zip))
+		tester.fail("Failed to open the archive.");
+	const auto stream = archive_file->open_entry_stream(0);
+	if (stream == nullptr)
+		tester.fail("Failed to open the entry stream.");
+	auto partial_data = Bytes(16);
+	const auto partial_read_size = stream->read(partial_data.data(), static_cast<int>(partial_data.size()));
+	const auto is_rewound = stream->rewind();
+	auto actual_data = Bytes(data.size());
+	const auto read_size = stream->read(actual_data.data(), static_cast<int>(actual_data.size()));
+	tester.check(partial_read_size == 16 && is_rewound && read_size == 64 && actual_data == data);
+}
+
+// ArchiveFileEntryStreamUPtr open_entry_stream(int) const
+// A deflated entry reads back byte for byte.
+void test_n1cb6mfxr8u3ypgo()
+{
+	const auto data = make_pattern_bytes(4096);
+	const auto zip = make_test_zip({make_deflated_entry("one.txt", data)});
+	const auto archive_file = bstone::make_zip_archive_file();
+	if (!open_test_zip(*archive_file, zip))
+		tester.fail("Failed to open the archive.");
+	const auto stream = archive_file->open_entry_stream(0);
+	if (stream == nullptr)
+		tester.fail("Failed to open the entry stream.");
+	auto actual_data = Bytes(data.size());
+	const auto read_size = stream->read(actual_data.data(), static_cast<int>(actual_data.size()));
+	tester.check(stream->get_size() == 4096 && read_size == 4096 && actual_data == data);
+}
+
+// ArchiveFileEntryStreamUPtr open_entry_stream(int) const
+// A deflated entry rewound while compressed bytes are still buffered decodes from the
+// beginning again.
+void test_y4jq0ei5tsl7dvzc()
+{
+	const auto data = make_pattern_bytes(32768);
+	const auto zip = make_test_zip({make_deflated_entry("one.txt", data)});
+	const auto archive_file = bstone::make_zip_archive_file();
+	if (!open_test_zip(*archive_file, zip))
+		tester.fail("Failed to open the archive.");
+	const auto stream = archive_file->open_entry_stream(0);
+	if (stream == nullptr)
+		tester.fail("Failed to open the entry stream.");
+	auto partial_data = Bytes(16);
+	const auto partial_read_size = stream->read(partial_data.data(), static_cast<int>(partial_data.size()));
+	const auto is_rewound = stream->rewind();
+	auto actual_data = Bytes(data.size());
+	const auto read_size = stream->read(actual_data.data(), static_cast<int>(actual_data.size()));
+	tester.check(partial_read_size == 16 && is_rewound && read_size == 32768 && actual_data == data);
+}
+
+// ArchiveFileEntryStreamUPtr open_entry_stream(int) const
+// A deflated entry that decodes to less than it promises stops instead of spinning.
+void test_g7pz9khn3bwr1amx()
+{
+	const auto data = make_pattern_bytes(4);
+	auto entry = make_deflated_entry("one.txt", data);
+	entry.uncompressed_size = 100000;
+	const auto zip = make_test_zip({entry});
+	const auto archive_file = bstone::make_zip_archive_file();
+	if (!open_test_zip(*archive_file, zip))
+		tester.fail("Failed to open the archive.");
+	const auto stream = archive_file->open_entry_stream(0);
+	if (stream == nullptr)
+		tester.fail("Failed to open the entry stream.");
+	auto actual_data = Bytes(100000);
+	const auto read_size = stream->read(actual_data.data(), static_cast<int>(actual_data.size()));
+	auto extra_byte = Bytes(1);
+	const auto extra_read_size = stream->read(extra_byte.data(), 1);
+	actual_data.resize(read_size > 0 ? static_cast<std::size_t>(read_size) : 0);
+	tester.check(read_size == 4 && actual_data == data && extra_read_size == 0);
+}
+
+// ==========================================================================
+
+class Registrator
+{
+public:
+	Registrator()
+	{
+		register_open_memory();
+		register_open_entry_stream();
+	}
+
+private:
+	void register_open_memory()
+	{
+		tester.register_test("ZipArchiveFile#q7m3xk1p9wz0aebt", test_q7m3xk1p9wz0aebt);
+		tester.register_test("ZipArchiveFile#h4nv82rjc6ylsq5d", test_h4nv82rjc6ylsq5d);
+		tester.register_test("ZipArchiveFile#z0f9tk3mwq7bxr14", test_z0f9tk3mwq7bxr14);
+		tester.register_test("ZipArchiveFile#p6ay5dn8hjv2ceu0", test_p6ay5dn8hjv2ceu0);
+		tester.register_test("ZipArchiveFile#r3wq7lz1o9skmv6t", test_r3wq7lz1o9skmv6t);
+		tester.register_test("ZipArchiveFile#b8xu4gyc2n5jhwq3", test_b8xu4gyc2n5jhwq3);
+		tester.register_test("ZipArchiveFile#k9td1rvp7f0mzsae", test_k9td1rvp7f0mzsae);
+	}
+
+	void register_open_entry_stream()
+	{
+		tester.register_test("ZipArchiveFile#c5ho3jw8qylb2unx", test_c5ho3jw8qylb2unx);
+		tester.register_test("ZipArchiveFile#w2ke7sza4vd9tlq6", test_w2ke7sza4vd9tlq6);
+		tester.register_test("ZipArchiveFile#n1cb6mfxr8u3ypgo", test_n1cb6mfxr8u3ypgo);
+		tester.register_test("ZipArchiveFile#y4jq0ei5tsl7dvzc", test_y4jq0ei5tsl7dvzc);
+		tester.register_test("ZipArchiveFile#g7pz9khn3bwr1amx", test_g7pz9khn3bwr1amx);
+	}
+};
+
+auto registrator = Registrator{};
+
+} // namespace


### PR DESCRIPTION
Hardens the ZIP archive reader against malformed input. Each fix turns a specific malformed shape that previously asserted, over-read, or looped into a rejected archive:

- Reject a malformed archive instead of asserting
- Size the entry name arena against a checked directory
- Clamp an extra field record to the field it lives in
- Make the entry stream size preconditions real checks
- Discard buffered input when an inflate entry rewinds
- Stop reading an inflate entry once its stream ends
- Reset the CRC accumulator when a stored entry rewinds
- Accept a zero-byte deflate member — the way Python's zipfile and .NET store an empty file — as a follow-up so the size checks do not drop legitimate members

Adds a test suite that builds well-formed and malformed archives in-test and exercises the reader with both, including the zero-byte deflate member.

Related to #558, which added the reader this hardens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
