### PR TITLE
Harden the movie decoder against malformed ANIM data

### DIFF
--- a/src/bstone/src/bstone_movie.cpp
+++ b/src/bstone/src/bstone_movie.cpp
@@ -223,6 +223,14 @@ bool Movie::get_frame()
 		binary_reader_.set_position(binary_reader_.get_size());
 		return false;
 	}
+	// The record size decides both how much payload a handler may consume and how far
+	// the reader advances afterwards. An oversized one hands out a payload that runs
+	// past the end of the file, and a negative one rewinds the reader onto the very
+	// same frame, so the movie would never end.
+	if (anim_frame_recsize_ < 0 || !binary_reader_.can_read_n(anim_frame_recsize_))
+	{
+		BSTONE_THROW_STATIC_SOURCE("Frame size out of range.");
+	}
 	return true;
 }
 
@@ -233,7 +241,7 @@ void Movie::handle_page(const Descriptor& descriptor)
 	{
 		case AN_SOUND:
 			// Sound Chunk
-			if (!binary_reader_.can_read_x16())
+			if (anim_frame_recsize_ < 2)
 			{
 				BSTONE_THROW_STATIC_SOURCE("No sound index.");
 			}
@@ -253,7 +261,7 @@ void Movie::handle_page(const Descriptor& descriptor)
 			break;
 		case AN_PAUSE:
 			// Pause
-			if (!binary_reader_.can_read_x16())
+			if (anim_frame_recsize_ < 2)
 			{
 				BSTONE_THROW_STATIC_SOURCE("No pause ticks.");
 			}

--- a/src/bstone/src/bstone_movie.cpp
+++ b/src/bstone/src/bstone_movie.cpp
@@ -203,6 +203,13 @@ void Movie::show_frame()
 		{
 			BSTONE_THROW_STATIC_SOURCE("Truncated draw data.");
 		}
+		// The chunk offset is an index into the screen buffer and VL_Plot clamps
+		// nothing, so a chunk reaching past the last pixel would write past the end
+		// of the buffer.
+		if (anim_chunk_offset + anim_chunk_length > vga_ref_width * vga_ref_height)
+		{
+			BSTONE_THROW_STATIC_SOURCE("Draw data out of screen.");
+		}
 		jm_draw_block(anim_chunk_offset, static_cast<const std::uint8_t*>(reader.get_current_data()), anim_chunk_length);
 		reader.skip(anim_chunk_length);
 	}


### PR DESCRIPTION
From a correctness review of wip: the movie reader trusted two values it read out of the file.

- Validate the frame record size — an oversized one hands out a payload that runs past the end of the file, and a negative one rewinds the reader onto the very same frame, so the movie never ends
- Keep an ANIM chunk inside the screen buffer — a chunk offset reaching past the last pixel wrote past the end of the buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)