### PR TITLE
Validate audio chunk data in the decoders

### DIFF
--- a/src/bstone/src/bstone_audio_extractor.cpp
+++ b/src/bstone/src/bstone_audio_extractor.cpp
@@ -188,7 +188,9 @@ void AudioExtractorImpl::write_non_digitized_audio_chunk(const AudioChunk& audio
 	}
 	stream.set_position(0);
 	if (!write_wav_header(data_size, bit_depth, dst_rate, channel_count, stream))
+	{
 		BSTONE_THROW_STATIC_SOURCE("Write error.");
+	}
 	const double volume_factor = 32'767.0 / abs_max_sample;
 	bstone::globals::logger->log_information("\tSample rate: {}", dst_rate);
 	bstone::globals::logger->log_information("\tSample count: {}", total_samples);

--- a/src/bstone/src/bstone_audio_extractor.cpp
+++ b/src/bstone/src/bstone_audio_extractor.cpp
@@ -187,7 +187,7 @@ void AudioExtractorImpl::write_non_digitized_audio_chunk(const AudioChunk& audio
 		total_samples += sample_count;
 	}
 	stream.set_position(0);
-	if (!write_wav_header(data_size, bit_depth, OplEmulator::fixed_sample_rate, channel_count, stream))
+	if (!write_wav_header(data_size, bit_depth, dst_rate, channel_count, stream))
 		BSTONE_THROW_STATIC_SOURCE("Write error.");
 	const double volume_factor = 32'767.0 / abs_max_sample;
 	bstone::globals::logger->log_information("\tSample rate: {}", dst_rate);

--- a/src/bstone/src/bstone_memory_binary_reader.cpp
+++ b/src/bstone/src/bstone_memory_binary_reader.cpp
@@ -39,7 +39,9 @@ void MemoryBinaryReader::skip(int count)
 
 bool MemoryBinaryReader::can_read_n(int count) const
 {
-	return size_ - position_ >= count;
+	// Counts often come from the data being parsed. A negative one would sail
+	// through the comparison below and vouch for a read that can not be made.
+	return count >= 0 && size_ - position_ >= count;
 }
 
 bool MemoryBinaryReader::can_read_x8() const

--- a/src/bstone/src/bstone_opl_sfx_decoder.cpp
+++ b/src/bstone/src/bstone_opl_sfx_decoder.cpp
@@ -34,6 +34,7 @@ public:
 
 private:
 	inline static constexpr int header_size = 23; // Original size of AdLibSound structure.
+	inline static constexpr int sfx_length_size = 4; // Size of the leading length field.
 	inline static constexpr int tick_rate = 140;
 
 	bool is_initialized_{};
@@ -96,7 +97,9 @@ bool OplSfxDecoder::initialize(const AudioDecoderInitParam& param)
 		set_error_message("Invalid command count.");
 		return false;
 	}
-	if (!reader_.can_read_n(header_size + sfx_length))
+	// The length comes from the chunk, so summing it with the header size would
+	// overflow the check into passing. Compare against what is left instead.
+	if (sfx_length > reader_.get_size() - sfx_length_size - header_size)
 	{
 		set_error_message("Command count mismatch.");
 		return false;

--- a/src/bstone/src/bstone_pc_speaker_audio_decoder.cpp
+++ b/src/bstone/src/bstone_pc_speaker_audio_decoder.cpp
@@ -170,7 +170,15 @@ int PcSpeakerAudioDecoder::decode_frames(float* samples, int max_frames)
 bool PcSpeakerAudioDecoder::rewind()
 {
 	BSTONE_ASSERT(is_initialized());
+	// The command counter and the PIT state carry the phase of the playback, so
+	// they have to go back to their initial values too for the sound to start
+	// over exactly as it did the first time.
 	command_offset_ = 0;
+	last_command_ = 0;
+	pit_signal_level_ = 0;
+	pit_counter_step_ = 0;
+	pit_counter_ = 0;
+	command_counter_ = dst_sample_rate_;
 	is_finished_ = false;
 	return true;
 }

--- a/src/bstone/src/bstone_pc_speaker_audio_decoder.cpp
+++ b/src/bstone/src/bstone_pc_speaker_audio_decoder.cpp
@@ -74,7 +74,14 @@ bool PcSpeakerAudioDecoder::initialize(const AudioDecoderInitParam& param)
 		set_error_message("Sample rate too small.");
 		return false;
 	}
+	// The command count is stored inside the chunk, so it can not be trusted to
+	// describe the bytes the chunk actually holds.
 	const int data_size = static_cast<int>(endian::read_u32_le(param.src_raw_data));
+	if (data_size < 0 || data_size > param.src_raw_size - min_src_size)
+	{
+		set_error_message("Command count out of range.");
+		return false;
+	}
 	dst_sample_rate_ = param.dst_rate;
 	commands_ = static_cast<const std::uint8_t*>(param.src_raw_data) + min_src_size;
 	commands_size_ = data_size;

--- a/src/bstone/src/bstone_wav_audio_decoder.cpp
+++ b/src/bstone/src/bstone_wav_audio_decoder.cpp
@@ -25,7 +25,10 @@ public:
 
 private:
 	inline static constexpr int max_channels = 2;
-	inline static constexpr int wav_min_meta_size = 44;
+	inline static constexpr int riff_header_size = 12;
+	inline static constexpr int chunk_header_size = 8;
+	inline static constexpr int fmt0x20_min_chunk_size = 16;
+	inline static constexpr int skip_buffer_size = 256;
 	inline static constexpr int byte_cache_capacity = 1024;
 	inline static constexpr int cache_capacity = byte_cache_capacity / (max_channels * static_cast<int>(sizeof(float)));
 
@@ -45,6 +48,7 @@ private:
 	int cache_frame_offset_counter_{};
 	int wav_size_{};
 	int wav_offset_{};
+	int data_offset_{};
 	ConvertSamplesFunc convert_samples_{};
 	Cache cache_{};
 	DecodeFramesFunc decode_frames_{};
@@ -56,7 +60,9 @@ private:
 	bool impl_wav_open();
 	void impl_terminate();
 	bool impl_initialize(const AudioDecoderInitParam& param);
-	bool impl_wav_read_meta(unsigned char (&meta)[wav_min_meta_size]);
+	bool impl_wav_read(void* buffer, int size);
+	bool impl_wav_skip(int size);
+	bool impl_wav_read_fmt0x20();
 
 	void convert_u8(const unsigned char* bytes, int sample_count);
 	void convert_s16(const unsigned char* bytes, int sample_count);
@@ -117,8 +123,7 @@ bool WavAudioDecoder::rewind()
 		set_error_message("Failed to reset a stream.");
 		return false;
 	}
-	unsigned char meta[wav_min_meta_size];
-	if (!impl_wav_read_meta(meta))
+	if (!impl_wav_skip(data_offset_))
 		return false;
 	cache_frame_count_ = 0;
 	cache_frame_offset_ = 0;
@@ -141,50 +146,172 @@ void WavAudioDecoder::impl_wav_close()
 {
 	wav_size_ = 0;
 	wav_offset_ = 0;
+	data_offset_ = 0;
 }
 
 bool WavAudioDecoder::impl_wav_open()
 {
-	constexpr int wav_max_chunk_size = 0x7FFFFFFF - 8;
-	constexpr int wav_format_pcm = 1;
-	constexpr int wav_format_ieee_float = 3;
-	constexpr unsigned int wav_max_file_size = 0x7FFFFFFFU - 8;
-	unsigned char meta[wav_min_meta_size];
-	if (!impl_wav_read_meta(meta))
+	constexpr unsigned int wav_max_chunk_size = 0x7FFFFFFFU - chunk_header_size;
+	unsigned char riff_header[riff_header_size];
+	if (!impl_wav_read(riff_header, riff_header_size))
 		return false;
-	MemoryBinaryReader reader{meta, wav_min_meta_size};
+	MemoryBinaryReader riff_reader{riff_header, riff_header_size};
 	// RIFF id
-	if (reader.read_u32_le() != 0x46464952U)
+	if (riff_reader.read_u32_le() != 0x46464952U)
 	{
 		set_error_message("Expected 'RIFF' chunk id.");
 		return false;
 	}
 	// RIFF chunk size
-	const unsigned int riff_chunk_size_u32 = reader.read_u32_le();
+	const unsigned int riff_chunk_size_u32 = riff_reader.read_u32_le();
 	if (riff_chunk_size_u32 > wav_max_chunk_size)
 	{
 		set_error_message("'RIFF' chunk size too big.");
 		return false;
 	}
 	// WAVE id
-	if (reader.read_u32_le() != 0x45564157U)
+	if (riff_reader.read_u32_le() != 0x45564157U)
 	{
 		set_error_message("Expected 'WAVE' chunk id.");
 		return false;
 	}
-	// "fmt " chunk id
-	if (reader.read_u32_le() != 0x20746D66U)
+	// Walk the chunks until "data" turns up. Nothing in the format promises
+	// that "fmt " and "data" are adjacent, or that "fmt " has no extension -
+	// encoders routinely interleave "fact", "LIST" or padding chunks.
+	const int riff_end_offset = static_cast<int>(riff_chunk_size_u32) + chunk_header_size;
+	bool has_fmt0x20 = false;
+	int offset = riff_header_size;
+	for (;;)
 	{
-		set_error_message("Expected 'fmt ' chunk id.");
+		if (riff_end_offset - offset < chunk_header_size)
+		{
+			set_error_message("Missing 'data' chunk.");
+			return false;
+		}
+		unsigned char chunk_header[chunk_header_size];
+		if (!impl_wav_read(chunk_header, chunk_header_size))
+			return false;
+		MemoryBinaryReader chunk_reader{chunk_header, chunk_header_size};
+		const unsigned int chunk_id_u32 = chunk_reader.read_u32_le();
+		const unsigned int chunk_size_u32 = chunk_reader.read_u32_le();
+		offset += chunk_header_size;
+		if (chunk_size_u32 > static_cast<unsigned int>(riff_end_offset - offset))
+		{
+			set_error_message("Chunk is beyond 'RIFF' bounds.");
+			return false;
+		}
+		const int chunk_size = static_cast<int>(chunk_size_u32);
+		switch (chunk_id_u32)
+		{
+			case 0x20746D66U: // "fmt "
+				if (has_fmt0x20)
+				{
+					set_error_message("Duplicate 'fmt ' chunk.");
+					return false;
+				}
+				if (chunk_size < fmt0x20_min_chunk_size)
+				{
+					set_error_message("Unsupported 'fmt ' chunk size.");
+					return false;
+				}
+				if (!impl_wav_read_fmt0x20())
+					return false;
+				if (!impl_wav_skip(chunk_size - fmt0x20_min_chunk_size))
+					return false;
+				has_fmt0x20 = true;
+				break;
+			case 0x61746164U: // "data"
+				if (!has_fmt0x20)
+				{
+					set_error_message("Missing 'fmt ' chunk.");
+					return false;
+				}
+				wav_size_ = chunk_size;
+				data_offset_ = offset;
+				return true;
+			default:
+				if (!impl_wav_skip(chunk_size))
+					return false;
+				break;
+		}
+		offset += chunk_size;
+		// Chunks are word-aligned, an odd-sized one is followed by a pad octet.
+		if ((chunk_size % 2) != 0)
+		{
+			if (!impl_wav_skip(1))
+				return false;
+			++offset;
+		}
+	}
+}
+
+void WavAudioDecoder::impl_terminate()
+{
+	is_initialized_ = false;
+	stream_ = nullptr;
+}
+
+bool WavAudioDecoder::impl_initialize(const AudioDecoderInitParam& param)
+{
+	if (param.vfs_stream == nullptr)
+	{
+		set_error_message("No VFS stream.");
 		return false;
 	}
-	// "fmt " chunk size
-	const unsigned int fmt0x20_chunk_size_u32 = reader.read_u32_le();
-	if (fmt0x20_chunk_size_u32 != 16)
+	if (param.dst_rate < 1)
 	{
-		set_error_message("Unsupported 'fmt ' chunk size.");
+		set_error_message("Invalid destination audio frame rate.");
 		return false;
 	}
+	stream_ = std::move(param.vfs_stream);
+	if (!impl_wav_open())
+		return false;
+	dst_sample_rate_ = param.dst_rate;
+	cache_frame_count_ = 0;
+	cache_frame_offset_ = 0;
+	cache_frame_offset_counter_ = 0;
+	if (src_sample_rate_ == param.dst_rate)
+		decode_frames_ = &WavAudioDecoder::decode_frames_as_is;
+	else
+		decode_frames_ = &WavAudioDecoder::decode_frames_with_resample;
+	is_initialized_ = true;
+	return true;
+}
+
+bool WavAudioDecoder::impl_wav_read(void* buffer, int size)
+{
+	if (!stream_->read_exactly(buffer, size))
+	{
+		set_error_message("Failed to read WAV meta data.");
+		return false;
+	}
+	return true;
+}
+
+bool WavAudioDecoder::impl_wav_skip(int size)
+{
+	BSTONE_ASSERT(size >= 0);
+	// The stream can only be read forward, so discard the bytes to skip over.
+	unsigned char buffer[skip_buffer_size];
+	int skipped_size = 0;
+	while (skipped_size < size)
+	{
+		const int read_size = std::min(size - skipped_size, skip_buffer_size);
+		if (!impl_wav_read(buffer, read_size))
+			return false;
+		skipped_size += read_size;
+	}
+	return true;
+}
+
+bool WavAudioDecoder::impl_wav_read_fmt0x20()
+{
+	constexpr int wav_format_pcm = 1;
+	constexpr int wav_format_ieee_float = 3;
+	unsigned char fmt0x20[fmt0x20_min_chunk_size];
+	if (!impl_wav_read(fmt0x20, fmt0x20_min_chunk_size))
+		return false;
+	MemoryBinaryReader reader{fmt0x20, fmt0x20_min_chunk_size};
 	// format tag
 	const int format_tag = reader.read_u16_le();
 	switch (format_tag)
@@ -253,79 +380,9 @@ bool WavAudioDecoder::impl_wav_open()
 		set_error_message("Invalid byte rate.");
 		return false;
 	}
-	// DATA id
-	if (reader.read_u32_le() != 0x61746164U)
-	{
-		set_error_message("Expected 'data' chunk id.");
-		return false;
-	}
-	// DATA chunk size
-	const unsigned int data_chunk_size_u32 = reader.read_u32_le();
-	if (data_chunk_size_u32 > wav_max_chunk_size)
-	{
-		set_error_message("Unsupported 'data' chunk size.");
-		return false;
-	}
-	// check for bounds
-	if (wav_max_file_size - 8 < riff_chunk_size_u32)
-	{
-		set_error_message("Chunk 'RIFF' out of bounds.");
-		return false;
-	}
-	const unsigned int riff_end_position = riff_chunk_size_u32 + 8;
-	if (data_chunk_size_u32 > riff_end_position ||
-		riff_end_position - data_chunk_size_u32 < wav_min_meta_size)
-	{
-		set_error_message("Chunk 'data' is beyond 'RIFF' bounds.");
-		return false;
-	}
 	channel_count_ = channel_count;
 	src_byte_depth_ = bit_depth / 8;
 	src_sample_rate_ = static_cast<int>(sample_rate_u32);
-	wav_size_ = static_cast<int>(data_chunk_size_u32);
-	return true;
-}
-
-void WavAudioDecoder::impl_terminate()
-{
-	is_initialized_ = false;
-	stream_ = nullptr;
-}
-
-bool WavAudioDecoder::impl_initialize(const AudioDecoderInitParam& param)
-{
-	if (param.vfs_stream == nullptr)
-	{
-		set_error_message("No VFS stream.");
-		return false;
-	}
-	if (param.dst_rate < 1)
-	{
-		set_error_message("Invalid destination audio frame rate.");
-		return false;
-	}
-	stream_ = std::move(param.vfs_stream);
-	if (!impl_wav_open())
-		return false;
-	dst_sample_rate_ = param.dst_rate;
-	cache_frame_count_ = 0;
-	cache_frame_offset_ = 0;
-	cache_frame_offset_counter_ = 0;
-	if (src_sample_rate_ == param.dst_rate)
-		decode_frames_ = &WavAudioDecoder::decode_frames_as_is;
-	else
-		decode_frames_ = &WavAudioDecoder::decode_frames_with_resample;
-	is_initialized_ = true;
-	return true;
-}
-
-bool WavAudioDecoder::impl_wav_read_meta(unsigned char (&meta)[wav_min_meta_size])
-{
-	if (!stream_->read_exactly(meta, wav_min_meta_size))
-	{
-		set_error_message("Failed to read WAV meta data.");
-		return false;
-	}
 	return true;
 }
 

--- a/src/bstone/src/bstone_wav_audio_decoder.cpp
+++ b/src/bstone/src/bstone_wav_audio_decoder.cpp
@@ -122,6 +122,7 @@ bool WavAudioDecoder::rewind()
 		return false;
 	cache_frame_count_ = 0;
 	cache_frame_offset_ = 0;
+	cache_frame_offset_counter_ = 0;
 	wav_offset_ = 0;
 	return true;
 }

--- a/src/bstone/src/bstone_wav_audio_decoder.cpp
+++ b/src/bstone/src/bstone_wav_audio_decoder.cpp
@@ -124,7 +124,9 @@ bool WavAudioDecoder::rewind()
 		return false;
 	}
 	if (!impl_wav_skip(data_offset_))
+	{
 		return false;
+	}
 	cache_frame_count_ = 0;
 	cache_frame_offset_ = 0;
 	cache_frame_offset_counter_ = 0;
@@ -154,7 +156,9 @@ bool WavAudioDecoder::impl_wav_open()
 	constexpr unsigned int wav_max_chunk_size = 0x7FFFFFFFU - chunk_header_size;
 	unsigned char riff_header[riff_header_size];
 	if (!impl_wav_read(riff_header, riff_header_size))
+	{
 		return false;
+	}
 	MemoryBinaryReader riff_reader{riff_header, riff_header_size};
 	// RIFF id
 	if (riff_reader.read_u32_le() != 0x46464952U)
@@ -190,7 +194,9 @@ bool WavAudioDecoder::impl_wav_open()
 		}
 		unsigned char chunk_header[chunk_header_size];
 		if (!impl_wav_read(chunk_header, chunk_header_size))
+		{
 			return false;
+		}
 		MemoryBinaryReader chunk_reader{chunk_header, chunk_header_size};
 		const unsigned int chunk_id_u32 = chunk_reader.read_u32_le();
 		const unsigned int chunk_size_u32 = chunk_reader.read_u32_le();
@@ -215,9 +221,13 @@ bool WavAudioDecoder::impl_wav_open()
 					return false;
 				}
 				if (!impl_wav_read_fmt0x20())
+				{
 					return false;
+				}
 				if (!impl_wav_skip(chunk_size - fmt0x20_min_chunk_size))
+				{
 					return false;
+				}
 				has_fmt0x20 = true;
 				break;
 			case 0x61746164U: // "data"
@@ -231,7 +241,9 @@ bool WavAudioDecoder::impl_wav_open()
 				return true;
 			default:
 				if (!impl_wav_skip(chunk_size))
+				{
 					return false;
+				}
 				break;
 		}
 		offset += chunk_size;
@@ -239,7 +251,9 @@ bool WavAudioDecoder::impl_wav_open()
 		if ((chunk_size % 2) != 0)
 		{
 			if (!impl_wav_skip(1))
+			{
 				return false;
+			}
 			++offset;
 		}
 	}
@@ -265,15 +279,21 @@ bool WavAudioDecoder::impl_initialize(const AudioDecoderInitParam& param)
 	}
 	stream_ = std::move(param.vfs_stream);
 	if (!impl_wav_open())
+	{
 		return false;
+	}
 	dst_sample_rate_ = param.dst_rate;
 	cache_frame_count_ = 0;
 	cache_frame_offset_ = 0;
 	cache_frame_offset_counter_ = 0;
 	if (src_sample_rate_ == param.dst_rate)
+	{
 		decode_frames_ = &WavAudioDecoder::decode_frames_as_is;
+	}
 	else
+	{
 		decode_frames_ = &WavAudioDecoder::decode_frames_with_resample;
+	}
 	is_initialized_ = true;
 	return true;
 }
@@ -298,7 +318,9 @@ bool WavAudioDecoder::impl_wav_skip(int size)
 	{
 		const int read_size = std::min(size - skipped_size, skip_buffer_size);
 		if (!impl_wav_read(buffer, read_size))
+		{
 			return false;
+		}
 		skipped_size += read_size;
 	}
 	return true;
@@ -310,7 +332,9 @@ bool WavAudioDecoder::impl_wav_read_fmt0x20()
 	constexpr int wav_format_ieee_float = 3;
 	unsigned char fmt0x20[fmt0x20_min_chunk_size];
 	if (!impl_wav_read(fmt0x20, fmt0x20_min_chunk_size))
+	{
 		return false;
+	}
 	MemoryBinaryReader reader{fmt0x20, fmt0x20_min_chunk_size};
 	// format tag
 	const int format_tag = reader.read_u16_le();

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -131,6 +131,7 @@ target_sources(bstone_tests
 		src/bstone_tests_steam_manifest.cpp
 		src/bstone_tests_vdf.cpp
 		src/bstone_tests_zip_archive_file.cpp
+		src/bstone_tests_memory_binary_reader.cpp
 	PRIVATE
 		src/bstone_tester.cpp
 		src/bstone_tester.h

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -107,6 +107,9 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_zip_archive_file.h
 		../../../bstone/src/bstone_zip_archive_file_crc_32.cpp
 		../../../bstone/src/bstone_zip_archive_file_crc_32.h
+		../../../bstone/src/bstone_audio_decoder.h
+		../../../bstone/src/bstone_pc_speaker_audio_decoder.cpp
+		../../../bstone/src/bstone_pc_speaker_audio_decoder.h
 	PRIVATE
 		src/bstone_tests_ascii.cpp
 		src/bstone_tests_char_conv.cpp
@@ -132,6 +135,7 @@ target_sources(bstone_tests
 		src/bstone_tests_vdf.cpp
 		src/bstone_tests_zip_archive_file.cpp
 		src/bstone_tests_memory_binary_reader.cpp
+		src/bstone_tests_pc_speaker_audio_decoder.cpp
 	PRIVATE
 		src/bstone_tester.cpp
 		src/bstone_tester.h

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -37,10 +37,10 @@ target_link_libraries(bstone_tests
 	PRIVATE
 		${CMAKE_DL_LIBS}
 		bstone::lib::dr_flac
+			bstone::lib::nuked_opl3
 		bstone::lib::sdl
 		bstone::lib::stb_vorbis
 		bstone::lib::zlib
-		bstone::lib::nuked_opl3
 )
 
 target_sources(bstone_tests
@@ -52,7 +52,6 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_endian.cpp
 		../../../bstone/src/bstone_endian.h
 		../../../bstone/src/bstone_scope_exit.h
-		../../../bstone/src/bstone_char_conv.cpp
 		../../../bstone/src/bstone_char_conv.cpp
 		../../../bstone/src/bstone_unique_resource.h
 		../../../bstone/src/bstone_cgm_vec.h
@@ -110,12 +109,8 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_zip_archive_file_crc_32.cpp
 		../../../bstone/src/bstone_zip_archive_file_crc_32.h
 		../../../bstone/src/bstone_audio_decoder.h
-		../../../bstone/src/bstone_pc_speaker_audio_decoder.cpp
-		../../../bstone/src/bstone_pc_speaker_audio_decoder.h
 		../../../bstone/src/bstone_audio_sample_converter.cpp
 		../../../bstone/src/bstone_audio_sample_converter.h
-		../../../bstone/src/bstone_opl_sfx_decoder.cpp
-		../../../bstone/src/bstone_opl_sfx_decoder.h
 		../../../bstone/src/bstone_opl_emulator.cpp
 		../../../bstone/src/bstone_opl_emulator.h
 		../../../bstone/src/bstone_opl_utility.cpp
@@ -128,6 +123,10 @@ target_sources(bstone_tests
 		../../../bstone/src/dosbox/dbopl.h
 		../../../bstone/src/dosbox/mixer.cpp
 		../../../bstone/src/dosbox/mixer.h
+		../../../bstone/src/bstone_pc_speaker_audio_decoder.cpp
+		../../../bstone/src/bstone_pc_speaker_audio_decoder.h
+		../../../bstone/src/bstone_opl_sfx_decoder.cpp
+		../../../bstone/src/bstone_opl_sfx_decoder.h
 	PRIVATE
 		src/bstone_tests_ascii.cpp
 		src/bstone_tests_char_conv.cpp

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ target_compile_options(bstone_tests
 target_include_directories(bstone_tests
 	PRIVATE
 		${PROJECT_SOURCE_DIR}/../../../bstone/src
+		${PROJECT_SOURCE_DIR}/../../../bstone/src/dosbox
 )
 
 target_link_libraries(bstone_tests
@@ -39,6 +40,7 @@ target_link_libraries(bstone_tests
 		bstone::lib::sdl
 		bstone::lib::stb_vorbis
 		bstone::lib::zlib
+		bstone::lib::nuked_opl3
 )
 
 target_sources(bstone_tests
@@ -110,6 +112,22 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_audio_decoder.h
 		../../../bstone/src/bstone_pc_speaker_audio_decoder.cpp
 		../../../bstone/src/bstone_pc_speaker_audio_decoder.h
+		../../../bstone/src/bstone_audio_sample_converter.cpp
+		../../../bstone/src/bstone_audio_sample_converter.h
+		../../../bstone/src/bstone_opl_sfx_decoder.cpp
+		../../../bstone/src/bstone_opl_sfx_decoder.h
+		../../../bstone/src/bstone_opl_emulator.cpp
+		../../../bstone/src/bstone_opl_emulator.h
+		../../../bstone/src/bstone_opl_utility.cpp
+		../../../bstone/src/bstone_opl_utility.h
+		../../../bstone/src/bstone_dbopl_emulator.cpp
+		../../../bstone/src/bstone_dbopl_emulator.h
+		../../../bstone/src/bstone_nuked_opl3_emulator.cpp
+		../../../bstone/src/bstone_nuked_opl3_emulator.h
+		../../../bstone/src/dosbox/dbopl.cpp
+		../../../bstone/src/dosbox/dbopl.h
+		../../../bstone/src/dosbox/mixer.cpp
+		../../../bstone/src/dosbox/mixer.h
 	PRIVATE
 		src/bstone_tests_ascii.cpp
 		src/bstone_tests_char_conv.cpp
@@ -136,6 +154,7 @@ target_sources(bstone_tests
 		src/bstone_tests_zip_archive_file.cpp
 		src/bstone_tests_memory_binary_reader.cpp
 		src/bstone_tests_pc_speaker_audio_decoder.cpp
+		src/bstone_tests_opl_sfx_decoder.cpp
 	PRIVATE
 		src/bstone_tester.cpp
 		src/bstone_tester.h

--- a/src/tests/src/tests/src/bstone_tests_memory_binary_reader.cpp
+++ b/src/tests/src/tests/src/bstone_tests_memory_binary_reader.cpp
@@ -1,0 +1,248 @@
+#include <cstdint>
+
+#include <limits>
+
+#include "bstone_memory_binary_reader.h"
+#include "bstone_tester.h"
+
+namespace {
+
+auto tester = bstone::Tester{};
+
+constexpr std::uint8_t test_data[8] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+
+// ==========================================================================
+
+// MemoryBinaryReader()
+void test_8z214ykyxfxr14b3()
+{
+	const auto reader = bstone::MemoryBinaryReader{};
+	const auto is_valid = reader.get_size() == 0 && !reader.can_read_x8();
+	tester.check(is_valid);
+}
+
+// MemoryBinaryReader(const void*, int)
+void test_djr24u31gl1diex9()
+{
+	const auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	const auto is_valid = reader.get_size() == 8 && reader.get_current_data() == test_data;
+	tester.check(is_valid);
+}
+
+// ==========================================================================
+
+// void set_position(int)
+void test_ta7q1jby7efgnpx4()
+{
+	auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	reader.set_position(6);
+	const auto is_valid = reader.read_u16_le() == 0x8877U;
+	tester.check(is_valid);
+}
+
+// void set_position(int)
+// Out of range positions are clamped.
+void test_vbk02bh4q3qfadk4()
+{
+	auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	reader.set_position(1000);
+	const auto is_at_end = !reader.can_read_x8();
+	reader.set_position(-1000);
+	const auto is_at_begin = reader.read_u8() == 0x11U;
+	tester.check(is_at_end && is_at_begin);
+}
+
+// ==========================================================================
+
+// void skip(int)
+void test_ybwmn0y31zt4nst5()
+{
+	auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	reader.skip(4);
+	reader.skip(-2);
+	const auto is_valid = reader.read_u8() == 0x33U;
+	tester.check(is_valid);
+}
+
+// ==========================================================================
+
+// bool can_read_n(int) const
+void test_fy8fsvsdci71tmix()
+{
+	auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	const auto is_all_readable = reader.can_read_n(8) && !reader.can_read_n(9);
+	reader.skip(5);
+	const auto is_rest_readable = reader.can_read_n(3) && !reader.can_read_n(4);
+	tester.check(is_all_readable && is_rest_readable);
+}
+
+// bool can_read_n(int) const
+// A negative count vouches for nothing.
+void test_okqm1qess2tphyec()
+{
+	const auto reader = bstone::MemoryBinaryReader{test_data, 8};
+
+	const auto is_valid =
+		!reader.can_read_n(-1) &&
+		!reader.can_read_n(std::numeric_limits<int>::min());
+
+	tester.check(is_valid);
+}
+
+// bool can_read_n(int) const
+// Zero octets are always readable.
+void test_p837r8095vzlzeov()
+{
+	auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	reader.set_position(8);
+	const auto is_valid = reader.can_read_n(0);
+	tester.check(is_valid);
+}
+
+// ==========================================================================
+
+// bool can_read_x8() const
+// bool can_read_x16() const
+// bool can_read_x32() const
+void test_kwqfnzljiljigmxm()
+{
+	auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	reader.set_position(5);
+	const auto is_valid = reader.can_read_x8() && !reader.can_read_x32();
+	reader.set_position(6);
+	const auto is_still_valid = reader.can_read_x16() && !reader.can_read_x32();
+	tester.check(is_valid && is_still_valid);
+}
+
+// ==========================================================================
+
+// std::int8_t read_s8()
+// std::uint8_t read_u8()
+void test_guyqluiqpau0uzug()
+{
+	auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	const auto u8 = reader.read_u8();
+	reader.set_position(7);
+	const auto s8 = reader.read_s8();
+	const auto is_valid = u8 == 0x11U && s8 == -120;
+	tester.check(is_valid);
+}
+
+// ==========================================================================
+
+// std::int16_t read_s16_le()
+// std::uint16_t read_u16_le()
+void test_sc33hg54x0sgyyyi()
+{
+	auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	const auto u16 = reader.read_u16_le();
+	reader.set_position(6);
+	const auto s16 = reader.read_s16_le();
+	const auto is_valid = u16 == 0x2211U && s16 == -30601;
+	tester.check(is_valid);
+}
+
+// ==========================================================================
+
+// std::int32_t read_s32_le()
+// std::uint32_t read_u32_le()
+void test_r8ynd62wn6h544nr()
+{
+	auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	const auto u32 = reader.read_u32_le();
+	const auto s32 = reader.read_s32_le();
+	const auto is_valid = u32 == 0x44332211U && s32 == -2005440939;
+	tester.check(is_valid);
+}
+
+// ==========================================================================
+
+// void read(void*, int)
+void test_dyeqho9i94ssnjdo()
+{
+	auto reader = bstone::MemoryBinaryReader{test_data, 8};
+	reader.skip(4);
+	std::uint8_t buffer[4] = {};
+	reader.read(buffer, 4);
+
+	const auto is_valid =
+		buffer[0] == 0x55U &&
+		buffer[1] == 0x66U &&
+		buffer[2] == 0x77U &&
+		buffer[3] == 0x88U;
+
+	tester.check(is_valid);
+}
+
+// ==========================================================================
+
+class Registrator
+{
+public:
+	Registrator()
+	{
+		register_ctor();
+		register_set_position();
+		register_skip();
+		register_can_read_n();
+		register_can_read_x();
+		register_read_8();
+		register_read_16();
+		register_read_32();
+		register_read();
+	}
+
+private:
+	void register_ctor()
+	{
+		tester.register_test("MemoryBinaryReader#8z214ykyxfxr14b3", test_8z214ykyxfxr14b3);
+		tester.register_test("MemoryBinaryReader#djr24u31gl1diex9", test_djr24u31gl1diex9);
+	}
+
+	void register_set_position()
+	{
+		tester.register_test("MemoryBinaryReader#ta7q1jby7efgnpx4", test_ta7q1jby7efgnpx4);
+		tester.register_test("MemoryBinaryReader#vbk02bh4q3qfadk4", test_vbk02bh4q3qfadk4);
+	}
+
+	void register_skip()
+	{
+		tester.register_test("MemoryBinaryReader#ybwmn0y31zt4nst5", test_ybwmn0y31zt4nst5);
+	}
+
+	void register_can_read_n()
+	{
+		tester.register_test("MemoryBinaryReader#fy8fsvsdci71tmix", test_fy8fsvsdci71tmix);
+		tester.register_test("MemoryBinaryReader#okqm1qess2tphyec", test_okqm1qess2tphyec);
+		tester.register_test("MemoryBinaryReader#p837r8095vzlzeov", test_p837r8095vzlzeov);
+	}
+
+	void register_can_read_x()
+	{
+		tester.register_test("MemoryBinaryReader#kwqfnzljiljigmxm", test_kwqfnzljiljigmxm);
+	}
+
+	void register_read_8()
+	{
+		tester.register_test("MemoryBinaryReader#guyqluiqpau0uzug", test_guyqluiqpau0uzug);
+	}
+
+	void register_read_16()
+	{
+		tester.register_test("MemoryBinaryReader#sc33hg54x0sgyyyi", test_sc33hg54x0sgyyyi);
+	}
+
+	void register_read_32()
+	{
+		tester.register_test("MemoryBinaryReader#r8ynd62wn6h544nr", test_r8ynd62wn6h544nr);
+	}
+
+	void register_read()
+	{
+		tester.register_test("MemoryBinaryReader#dyeqho9i94ssnjdo", test_dyeqho9i94ssnjdo);
+	}
+};
+
+auto registrator = Registrator{};
+
+} // namespace

--- a/src/tests/src/tests/src/bstone_tests_memory_binary_reader.cpp
+++ b/src/tests/src/tests/src/bstone_tests_memory_binary_reader.cpp
@@ -2,16 +2,200 @@
 
 #include <limits>
 
-#include "bstone_memory_binary_reader.h"
 #include "bstone_tester.h"
+
+#include "bstone_memory_binary_reader.h"
 
 namespace {
 
 auto tester = bstone::Tester{};
 
+const std::uint8_t bytes[8] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
 constexpr std::uint8_t test_data[8] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
 
 // ==========================================================================
+
+// MemoryBinaryReader()
+void test_q7m4xk2vd9zr1ha3()
+{
+	const auto reader = bstone::MemoryBinaryReader{};
+	tester.check(reader.get_size() == 0);
+}
+
+// MemoryBinaryReader(const void*, int)
+void test_b3t8nw5cj0plye6u()
+{
+	const auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	const auto is_valid_size = reader.get_size() == 8;
+	const auto is_valid_data = reader.get_current_data() == bytes;
+	tester.check(is_valid_size && is_valid_data);
+}
+
+// ==========================================================================
+
+// const void* get_current_data() const
+void test_z5hf1cyp8n3wqk7t()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	reader.skip(3);
+	tester.check(reader.get_current_data() == &bytes[3]);
+}
+
+// ==========================================================================
+
+// void set_position(int)
+void test_r2vjx6ma0eb9ts4l()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	reader.set_position(5);
+	const auto is_valid_position = reader.get_current_data() == &bytes[5];
+	reader.set_position(-100);
+	const auto is_clamped_to_begin = reader.get_current_data() == bytes;
+	reader.set_position(100);
+	const auto is_clamped_to_end = reader.get_current_data() == &bytes[8];
+	tester.check(is_valid_position && is_clamped_to_begin && is_clamped_to_end);
+}
+
+// ==========================================================================
+
+// void skip(int)
+void test_n8plq3zd5kw7cy1x()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	reader.skip(2);
+	const auto is_valid_position_1 = reader.get_current_data() == &bytes[2];
+	reader.skip(4);
+	const auto is_valid_position_2 = reader.get_current_data() == &bytes[6];
+	tester.check(is_valid_position_1 && is_valid_position_2);
+}
+
+// A negative count moves the position backwards.
+void test_w4cs9gtb2meh6ru0()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	reader.skip(6);
+	reader.skip(-4);
+	const auto is_rewound = reader.get_current_data() == &bytes[2];
+	reader.skip(-100);
+	const auto is_clamped_to_begin = reader.get_current_data() == bytes;
+	tester.check(is_rewound && is_clamped_to_begin);
+}
+
+// ==========================================================================
+
+// bool can_read_n(int) const
+void test_e6yn0kfa7jvx3qd2()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	const auto can_read_all = reader.can_read_n(8);
+	const auto can_read_too_much = reader.can_read_n(9);
+	reader.skip(6);
+	const auto can_read_rest = reader.can_read_n(2);
+	const auto can_read_past_rest = reader.can_read_n(3);
+	tester.check(can_read_all && !can_read_too_much && can_read_rest && !can_read_past_rest);
+}
+
+// bool can_read_x8() const
+// bool can_read_x16() const
+// bool can_read_x32() const
+void test_t1zb5rho4pcm8ws9()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	reader.skip(4);
+	const auto can_read_x32 = reader.can_read_x32();
+	reader.skip(1);
+	const auto can_not_read_x32 = !reader.can_read_x32();
+	reader.skip(1);
+	const auto can_read_x16 = reader.can_read_x16();
+	reader.skip(1);
+	const auto can_not_read_x16 = !reader.can_read_x16();
+	const auto can_read_x8 = reader.can_read_x8();
+	reader.skip(1);
+	const auto can_not_read_x8 = !reader.can_read_x8();
+
+	tester.check(
+		can_read_x32 &&
+		can_not_read_x32 &&
+		can_read_x16 &&
+		can_not_read_x16 &&
+		can_read_x8 &&
+		can_not_read_x8);
+}
+
+// ==========================================================================
+
+// std::int8_t read_s8()
+void test_g0uk7dxq9lna2vf5()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	reader.skip(7);
+	const std::int8_t value = reader.read_s8();
+	tester.check(value == static_cast<std::int8_t>(0x88));
+}
+
+// std::uint8_t read_u8()
+void test_m3wp6svr1oyc4hz8()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	const std::uint8_t value_1 = reader.read_u8();
+	const std::uint8_t value_2 = reader.read_u8();
+	tester.check(value_1 == 0x11 && value_2 == 0x22);
+}
+
+// std::int16_t read_s16_le()
+void test_c7jl4bnf2xqu0kd6()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	reader.skip(6);
+	const std::int16_t value = reader.read_s16_le();
+	tester.check(value == static_cast<std::int16_t>(0x8877));
+}
+
+// std::uint16_t read_u16_le()
+void test_y9rt3ahz6egm5pv1()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	const std::uint16_t value = reader.read_u16_le();
+	const auto is_advanced = reader.get_current_data() == &bytes[2];
+	tester.check(value == 0x2211 && is_advanced);
+}
+
+// std::int32_t read_s32_le()
+void test_d2fx8qwc5ivb7no4()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	reader.skip(4);
+	const std::int32_t value = reader.read_s32_le();
+	tester.check(value == static_cast<std::int32_t>(0x88776655U));
+}
+
+// std::uint32_t read_u32_le()
+void test_s5nk1eop3rtd9ug7()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	const std::uint32_t value = reader.read_u32_le();
+	const auto is_advanced = reader.get_current_data() == &bytes[4];
+	tester.check(value == 0x44332211U && is_advanced);
+}
+
+// ==========================================================================
+
+// void read(void*, int)
+void test_h6qm2yvl8bxa4jc0()
+{
+	auto reader = bstone::MemoryBinaryReader{bytes, 8};
+	reader.skip(2);
+	std::uint8_t buffer[3] = {};
+	reader.read(buffer, 3);
+	const auto is_valid_value = buffer[0] == 0x33 && buffer[1] == 0x44 && buffer[2] == 0x55;
+	const auto is_advanced = reader.get_current_data() == &bytes[5];
+	tester.check(is_valid_value && is_advanced);
+}
+
+// ==========================================================================
+
+// ==========================================================================
+
 
 // MemoryBinaryReader()
 void test_8z214ykyxfxr14b3()
@@ -182,8 +366,10 @@ public:
 	Registrator()
 	{
 		register_ctor();
+		register_get_current_data();
 		register_set_position();
 		register_skip();
+		register_can_read();
 		register_can_read_n();
 		register_can_read_x();
 		register_read_8();
@@ -195,19 +381,35 @@ public:
 private:
 	void register_ctor()
 	{
+		tester.register_test("MemoryBinaryReader#q7m4xk2vd9zr1ha3", test_q7m4xk2vd9zr1ha3);
+		tester.register_test("MemoryBinaryReader#b3t8nw5cj0plye6u", test_b3t8nw5cj0plye6u);
 		tester.register_test("MemoryBinaryReader#8z214ykyxfxr14b3", test_8z214ykyxfxr14b3);
 		tester.register_test("MemoryBinaryReader#djr24u31gl1diex9", test_djr24u31gl1diex9);
 	}
 
+	void register_get_current_data()
+	{
+		tester.register_test("MemoryBinaryReader#z5hf1cyp8n3wqk7t", test_z5hf1cyp8n3wqk7t);
+	}
+
 	void register_set_position()
 	{
+		tester.register_test("MemoryBinaryReader#r2vjx6ma0eb9ts4l", test_r2vjx6ma0eb9ts4l);
 		tester.register_test("MemoryBinaryReader#ta7q1jby7efgnpx4", test_ta7q1jby7efgnpx4);
 		tester.register_test("MemoryBinaryReader#vbk02bh4q3qfadk4", test_vbk02bh4q3qfadk4);
 	}
 
 	void register_skip()
 	{
+		tester.register_test("MemoryBinaryReader#n8plq3zd5kw7cy1x", test_n8plq3zd5kw7cy1x);
+		tester.register_test("MemoryBinaryReader#w4cs9gtb2meh6ru0", test_w4cs9gtb2meh6ru0);
 		tester.register_test("MemoryBinaryReader#ybwmn0y31zt4nst5", test_ybwmn0y31zt4nst5);
+	}
+
+	void register_can_read()
+	{
+		tester.register_test("MemoryBinaryReader#e6yn0kfa7jvx3qd2", test_e6yn0kfa7jvx3qd2);
+		tester.register_test("MemoryBinaryReader#t1zb5rho4pcm8ws9", test_t1zb5rho4pcm8ws9);
 	}
 
 	void register_can_read_n()
@@ -239,6 +441,13 @@ private:
 
 	void register_read()
 	{
+		tester.register_test("MemoryBinaryReader#g0uk7dxq9lna2vf5", test_g0uk7dxq9lna2vf5);
+		tester.register_test("MemoryBinaryReader#m3wp6svr1oyc4hz8", test_m3wp6svr1oyc4hz8);
+		tester.register_test("MemoryBinaryReader#c7jl4bnf2xqu0kd6", test_c7jl4bnf2xqu0kd6);
+		tester.register_test("MemoryBinaryReader#y9rt3ahz6egm5pv1", test_y9rt3ahz6egm5pv1);
+		tester.register_test("MemoryBinaryReader#d2fx8qwc5ivb7no4", test_d2fx8qwc5ivb7no4);
+		tester.register_test("MemoryBinaryReader#s5nk1eop3rtd9ug7", test_s5nk1eop3rtd9ug7);
+		tester.register_test("MemoryBinaryReader#h6qm2yvl8bxa4jc0", test_h6qm2yvl8bxa4jc0);
 		tester.register_test("MemoryBinaryReader#dyeqho9i94ssnjdo", test_dyeqho9i94ssnjdo);
 	}
 };

--- a/src/tests/src/tests/src/bstone_tests_opl_sfx_decoder.cpp
+++ b/src/tests/src/tests/src/bstone_tests_opl_sfx_decoder.cpp
@@ -1,0 +1,229 @@
+#include <cstdint>
+#include <cstring>
+
+#include <limits>
+#include <vector>
+
+#include "bstone_opl_sfx_decoder.h"
+#include "bstone_tester.h"
+
+namespace {
+
+auto tester = bstone::Tester{};
+
+// The decoder requires a chunk to hold the 23-octet AdLibSound header, the
+// commands, and the leading length field counted a second time.
+constexpr int min_chunk_size = 27;
+
+constexpr auto test_emulator_type = bstone::OplEmulatorType::dbopl;
+
+using Chunk = std::vector<std::uint8_t>;
+
+// Makes an OPL SFX chunk with a command count of `sfx_length` and room for
+// `command_count` commands.
+Chunk make_chunk(std::uint32_t sfx_length, int command_count)
+{
+	auto chunk = Chunk(static_cast<std::size_t>(min_chunk_size + command_count));
+	chunk[0] = static_cast<std::uint8_t>(sfx_length);
+	chunk[1] = static_cast<std::uint8_t>(sfx_length >> 8);
+	chunk[2] = static_cast<std::uint8_t>(sfx_length >> 16);
+	chunk[3] = static_cast<std::uint8_t>(sfx_length >> 24);
+	chunk[12] = 0x0F; // Modulator sustain.
+	chunk[13] = 0x0F; // Carrier sustain.
+	chunk[22] = 0x02; // Block.
+
+	for (int i = 0; i < command_count; ++i)
+		chunk[static_cast<std::size_t>(23 + i)] = 0x40;
+
+	return chunk;
+}
+
+// ==========================================================================
+
+// bool initialize(const AudioDecoderInitParam&)
+void test_iio7snjvd13n45mq()
+{
+	const auto chunk = make_chunk(2, 2);
+	auto decoder = bstone::make_opl_sfx_audio_decoder(test_emulator_type);
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = bstone::OplEmulator::fixed_sample_rate});
+
+	tester.check(is_initialized && decoder->get_channel_count() > 0);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// A command count that overruns the chunk is rejected.
+void test_1qv6tag86x6csx62()
+{
+	const auto chunk = make_chunk(3, 2);
+	auto decoder = bstone::make_opl_sfx_audio_decoder(test_emulator_type);
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = bstone::OplEmulator::fixed_sample_rate});
+
+	tester.check(!is_initialized && !decoder->is_initialized());
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// A command count big enough to overflow the bounds check is rejected.
+void test_7zmclziabp1uoi0t()
+{
+	const auto chunk = make_chunk(
+		static_cast<std::uint32_t>(std::numeric_limits<int>::max()), 2);
+
+	auto decoder = bstone::make_opl_sfx_audio_decoder(test_emulator_type);
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = bstone::OplEmulator::fixed_sample_rate});
+
+	const auto is_valid =
+		!is_initialized &&
+		std::strcmp(decoder->get_error_message(), "Command count mismatch.") == 0;
+
+	tester.check(is_valid);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// A command count with the sign bit set is rejected.
+void test_vbe1vlwzo68ez2we()
+{
+	const auto chunk = make_chunk(0x80000000U, 2);
+	auto decoder = bstone::make_opl_sfx_audio_decoder(test_emulator_type);
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = bstone::OplEmulator::fixed_sample_rate});
+
+	tester.check(!is_initialized);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// An empty command stream is rejected.
+void test_yl2h5m7aaycrxla7()
+{
+	const auto chunk = make_chunk(0, 2);
+	auto decoder = bstone::make_opl_sfx_audio_decoder(test_emulator_type);
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = bstone::OplEmulator::fixed_sample_rate});
+
+	tester.check(!is_initialized);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// A chunk too small to hold the length field is rejected.
+void test_d1ra96j5lh0dpym3()
+{
+	const auto chunk = make_chunk(2, 2);
+	auto decoder = bstone::make_opl_sfx_audio_decoder(test_emulator_type);
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = 3,
+			.dst_rate = bstone::OplEmulator::fixed_sample_rate});
+
+	tester.check(!is_initialized);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// An instrument with no sustain at all is rejected.
+void test_rj4j6846djiip7kv()
+{
+	auto chunk = make_chunk(2, 2);
+	chunk[12] = 0;
+	chunk[13] = 0;
+	auto decoder = bstone::make_opl_sfx_audio_decoder(test_emulator_type);
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = bstone::OplEmulator::fixed_sample_rate});
+
+	tester.check(!is_initialized);
+}
+
+// ==========================================================================
+
+// int decode_frames(float*, int)
+void test_xn3uft1b86gvchbn()
+{
+	constexpr int max_frames = 512;
+	const auto chunk = make_chunk(2, 2);
+	auto decoder = bstone::make_opl_sfx_audio_decoder(test_emulator_type);
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = bstone::OplEmulator::fixed_sample_rate});
+
+	if (!is_initialized)
+	{
+		tester.check(false);
+		return;
+	}
+
+	auto samples = std::vector<float>(
+		static_cast<std::size_t>(max_frames * decoder->get_channel_count()));
+
+	const auto frame_count = decoder->decode_frames(samples.data(), max_frames);
+	tester.check(frame_count == max_frames);
+}
+
+// ==========================================================================
+
+class Registrator
+{
+public:
+	Registrator()
+	{
+		register_initialize();
+		register_decode_frames();
+	}
+
+private:
+	void register_initialize()
+	{
+		tester.register_test("OplSfxDecoder#iio7snjvd13n45mq", test_iio7snjvd13n45mq);
+		tester.register_test("OplSfxDecoder#1qv6tag86x6csx62", test_1qv6tag86x6csx62);
+		tester.register_test("OplSfxDecoder#7zmclziabp1uoi0t", test_7zmclziabp1uoi0t);
+		tester.register_test("OplSfxDecoder#vbe1vlwzo68ez2we", test_vbe1vlwzo68ez2we);
+		tester.register_test("OplSfxDecoder#yl2h5m7aaycrxla7", test_yl2h5m7aaycrxla7);
+		tester.register_test("OplSfxDecoder#d1ra96j5lh0dpym3", test_d1ra96j5lh0dpym3);
+		tester.register_test("OplSfxDecoder#rj4j6846djiip7kv", test_rj4j6846djiip7kv);
+	}
+
+	void register_decode_frames()
+	{
+		tester.register_test("OplSfxDecoder#xn3uft1b86gvchbn", test_xn3uft1b86gvchbn);
+	}
+};
+
+auto registrator = Registrator{};
+
+} // namespace

--- a/src/tests/src/tests/src/bstone_tests_opl_sfx_decoder.cpp
+++ b/src/tests/src/tests/src/bstone_tests_opl_sfx_decoder.cpp
@@ -33,7 +33,9 @@ Chunk make_chunk(std::uint32_t sfx_length, int command_count)
 	chunk[22] = 0x02; // Block.
 
 	for (int i = 0; i < command_count; ++i)
+	{
 		chunk[static_cast<std::size_t>(23 + i)] = 0x40;
+	}
 
 	return chunk;
 }

--- a/src/tests/src/tests/src/bstone_tests_pc_speaker_audio_decoder.cpp
+++ b/src/tests/src/tests/src/bstone_tests_pc_speaker_audio_decoder.cpp
@@ -180,6 +180,39 @@ void test_4e4mervbv9g39vqa()
 
 // ==========================================================================
 
+// bool rewind()
+// A rewound sound plays back exactly as it did the first time.
+void test_wujzbduytphe9hvl()
+{
+	constexpr int command_count = 2;
+	const auto chunk = make_chunk(command_count, command_count);
+	auto decoder = bstone::make_pc_speaker_audio_decoder();
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = test_dst_rate});
+
+	auto first_samples = std::vector<float>(test_dst_rate);
+	const auto first_frame_count = decoder->decode_frames(first_samples.data(), test_dst_rate);
+	const auto is_rewound = decoder->rewind();
+	auto second_samples = std::vector<float>(test_dst_rate);
+	const auto second_frame_count = decoder->decode_frames(second_samples.data(), test_dst_rate);
+
+	const auto is_valid =
+		is_initialized &&
+		is_rewound &&
+		first_frame_count == command_count * test_frames_per_command &&
+		second_frame_count == first_frame_count &&
+		first_samples == second_samples;
+
+	tester.check(is_valid);
+}
+
+// ==========================================================================
+
 class Registrator
 {
 public:
@@ -187,6 +220,7 @@ public:
 	{
 		register_initialize();
 		register_decode_frames();
+		register_rewind();
 	}
 
 private:
@@ -204,6 +238,11 @@ private:
 	void register_decode_frames()
 	{
 		tester.register_test("PcSpeakerAudioDecoder#4e4mervbv9g39vqa", test_4e4mervbv9g39vqa);
+	}
+
+	void register_rewind()
+	{
+		tester.register_test("PcSpeakerAudioDecoder#wujzbduytphe9hvl", test_wujzbduytphe9hvl);
 	}
 };
 

--- a/src/tests/src/tests/src/bstone_tests_pc_speaker_audio_decoder.cpp
+++ b/src/tests/src/tests/src/bstone_tests_pc_speaker_audio_decoder.cpp
@@ -27,7 +27,9 @@ Chunk make_chunk(std::uint32_t command_count, int command_octet_count)
 	chunk[3] = static_cast<std::uint8_t>(command_count >> 24);
 
 	for (int i = 0; i < command_octet_count; ++i)
+	{
 		chunk[static_cast<std::size_t>(6 + i)] = static_cast<std::uint8_t>(0x40 + i);
+	}
 
 	return chunk;
 }

--- a/src/tests/src/tests/src/bstone_tests_pc_speaker_audio_decoder.cpp
+++ b/src/tests/src/tests/src/bstone_tests_pc_speaker_audio_decoder.cpp
@@ -1,0 +1,212 @@
+#include <cstdint>
+
+#include <vector>
+
+#include "bstone_pc_speaker_audio_decoder.h"
+#include "bstone_tester.h"
+
+namespace {
+
+auto tester = bstone::Tester{};
+
+// A rate that is an exact multiple of the 140 Hz command rate, so that every
+// command lasts a whole number of frames.
+constexpr int test_dst_rate = 4200;
+constexpr int test_frames_per_command = test_dst_rate / 140;
+
+using Chunk = std::vector<std::uint8_t>;
+
+// Makes a PC Speaker chunk: a 32-bit little-endian command count, two octets
+// of padding and then one octet per command.
+Chunk make_chunk(std::uint32_t command_count, int command_octet_count)
+{
+	auto chunk = Chunk(static_cast<std::size_t>(6 + command_octet_count));
+	chunk[0] = static_cast<std::uint8_t>(command_count);
+	chunk[1] = static_cast<std::uint8_t>(command_count >> 8);
+	chunk[2] = static_cast<std::uint8_t>(command_count >> 16);
+	chunk[3] = static_cast<std::uint8_t>(command_count >> 24);
+
+	for (int i = 0; i < command_octet_count; ++i)
+		chunk[static_cast<std::size_t>(6 + i)] = static_cast<std::uint8_t>(0x40 + i);
+
+	return chunk;
+}
+
+// ==========================================================================
+
+// bool initialize(const AudioDecoderInitParam&)
+void test_80rrg3cr9xrcamri()
+{
+	const auto chunk = make_chunk(2, 2);
+	auto decoder = bstone::make_pc_speaker_audio_decoder();
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = test_dst_rate});
+
+	tester.check(is_initialized && decoder->get_channel_count() == 1);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// A command count that overruns the chunk is rejected.
+void test_ap8nzhx4xjbnj9gq()
+{
+	const auto chunk = make_chunk(3, 2);
+	auto decoder = bstone::make_pc_speaker_audio_decoder();
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = test_dst_rate});
+
+	tester.check(!is_initialized && !decoder->is_initialized());
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// A command count with the sign bit set is rejected.
+void test_9v6lt36c9wejy81l()
+{
+	const auto chunk = make_chunk(0xFFFFFFFFU, 2);
+	auto decoder = bstone::make_pc_speaker_audio_decoder();
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = test_dst_rate});
+
+	tester.check(!is_initialized && !decoder->is_initialized());
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// A chunk with a trailing terminator octet, as the shipped ones have.
+void test_o08xhaxbuvfilq7q()
+{
+	const auto chunk = make_chunk(2, 3);
+	auto decoder = bstone::make_pc_speaker_audio_decoder();
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = test_dst_rate});
+
+	tester.check(is_initialized);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// A chunk too small to hold the header is rejected.
+void test_6v5ultp3usjc29fj()
+{
+	const auto chunk = make_chunk(0, 0);
+	auto decoder = bstone::make_pc_speaker_audio_decoder();
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = 5,
+			.dst_rate = test_dst_rate});
+
+	tester.check(!is_initialized);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+void test_d4xdxn8nf9gux1z8()
+{
+	auto decoder = bstone::make_pc_speaker_audio_decoder();
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = nullptr,
+			.src_raw_size = 16,
+			.dst_rate = test_dst_rate});
+
+	tester.check(!is_initialized);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// A destination rate at or below the command rate is rejected.
+void test_ywodxzuk80x287hf()
+{
+	const auto chunk = make_chunk(2, 2);
+	auto decoder = bstone::make_pc_speaker_audio_decoder();
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = 140});
+
+	tester.check(!is_initialized);
+}
+
+// ==========================================================================
+
+// int decode_frames(float*, int)
+void test_4e4mervbv9g39vqa()
+{
+	constexpr int command_count = 2;
+	const auto chunk = make_chunk(command_count, command_count);
+	auto decoder = bstone::make_pc_speaker_audio_decoder();
+
+	const auto is_initialized = decoder->initialize(
+		bstone::AudioDecoderInitParam{
+			.vfs_stream = bstone::VfsInputStreamUPtr{},
+			.src_raw_data = chunk.data(),
+			.src_raw_size = static_cast<int>(chunk.size()),
+			.dst_rate = test_dst_rate});
+
+	auto samples = std::vector<float>(test_dst_rate);
+	const auto frame_count = decoder->decode_frames(samples.data(), test_dst_rate);
+	const auto tail_frame_count = decoder->decode_frames(samples.data(), test_dst_rate);
+
+	const auto is_valid =
+		is_initialized &&
+		frame_count == command_count * test_frames_per_command &&
+		tail_frame_count == 0;
+
+	tester.check(is_valid);
+}
+
+// ==========================================================================
+
+class Registrator
+{
+public:
+	Registrator()
+	{
+		register_initialize();
+		register_decode_frames();
+	}
+
+private:
+	void register_initialize()
+	{
+		tester.register_test("PcSpeakerAudioDecoder#80rrg3cr9xrcamri", test_80rrg3cr9xrcamri);
+		tester.register_test("PcSpeakerAudioDecoder#ap8nzhx4xjbnj9gq", test_ap8nzhx4xjbnj9gq);
+		tester.register_test("PcSpeakerAudioDecoder#9v6lt36c9wejy81l", test_9v6lt36c9wejy81l);
+		tester.register_test("PcSpeakerAudioDecoder#o08xhaxbuvfilq7q", test_o08xhaxbuvfilq7q);
+		tester.register_test("PcSpeakerAudioDecoder#6v5ultp3usjc29fj", test_6v5ultp3usjc29fj);
+		tester.register_test("PcSpeakerAudioDecoder#d4xdxn8nf9gux1z8", test_d4xdxn8nf9gux1z8);
+		tester.register_test("PcSpeakerAudioDecoder#ywodxzuk80x287hf", test_ywodxzuk80x287hf);
+	}
+
+	void register_decode_frames()
+	{
+		tester.register_test("PcSpeakerAudioDecoder#4e4mervbv9g39vqa", test_4e4mervbv9g39vqa);
+	}
+};
+
+auto registrator = Registrator{};
+
+} // namespace


### PR DESCRIPTION
From a correctness review of wip: the audio decoders trusted sizes and counts read out of the chunks they decode.

- WAV: walk the chunks when opening — encoders routinely interleave "fact", "LIST" or padding chunks, and nothing promises "fmt " and "data" are adjacent; also clear the resampler phase on rewind so a looped sound starts over exactly as it began
- OPL SFX: keep the bounds check from overflowing on a hostile length
- PC Speaker: bound the command count by its chunk and restore the whole playback state on rewind
- MemoryBinaryReader: refuse a negative count — one from the parsed data would vouch for a read that cannot be made
- Declare the decoding rate in extracted SFX headers

Adds a twenty-eight case suite for MemoryBinaryReader and coverage for the OPL SFX and PC Speaker decoders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)