### PR TITLE
Fix audio mixer hangs and lifetime issues

### DIFF
--- a/src/bstone/src/bstone_oal_audio_mixer.cpp
+++ b/src/bstone/src/bstone_oal_audio_mixer.cpp
@@ -899,7 +899,9 @@ int OalAudioMixer::get_max_voice_count()
 	{
 		oal_source_resource = make_oal_source();
 		if (oal_source_resource.is_empty())
+		{
 			break;
+		}
 		++voice_count;
 	}
 	return voice_count;
@@ -1871,7 +1873,9 @@ void OalAudioMixer::mix_r3s_sfx(Voice& voice)
 void OalAudioMixer::r3s_update_oal_source()
 {
 	if (!r3s_sound_.is_initialized || !r3s_oal_source_.is_open())
+	{
 		return;
+	}
 	r3s_oal_source_.mix();
 }
 
@@ -1880,7 +1884,9 @@ void OalAudioMixer::mix_r3s()
 	// The mixing buffer is allocated only when the source is ready for it, so
 	// without a source there is nothing to mix into.
 	if (!r3s_sound_.is_initialized || !r3s_oal_source_.is_open())
+	{
 		return;
+	}
 	const int max_frames = mix_frame_count_ * oal_source_max_streaming_buffers;
 	while (r3s_sound_.queue_size < oal_source_max_streaming_buffers)
 	{

--- a/src/bstone/src/bstone_oal_audio_mixer.cpp
+++ b/src/bstone/src/bstone_oal_audio_mixer.cpp
@@ -1872,10 +1872,6 @@ void OalAudioMixer::mix_r3s_sfx(Voice& voice)
 
 void OalAudioMixer::r3s_update_oal_source()
 {
-	if (!r3s_sound_.is_initialized || !r3s_oal_source_.is_open())
-	{
-		return;
-	}
 	r3s_oal_source_.mix();
 }
 

--- a/src/bstone/src/bstone_oal_audio_mixer.cpp
+++ b/src/bstone/src/bstone_oal_audio_mixer.cpp
@@ -1787,18 +1787,25 @@ void OalAudioMixer::mix_r3s_music(Voice& voice)
 	const float gain = r3s_sound_.pre_gain * voice.r3s_gain;
 	float* const src_samples = samples_f32_.data();
 	int frame_offset = 0;
+	// A decoder with no decodable content - an empty OPL command block, an
+	// external file with no sample data - keeps returning no frames while
+	// happily rewinding. Stop the voice once a rewind fails to make progress
+	// instead of retrying it forever on the mixer thread.
+	bool is_rewound = false;
 	while (frame_offset < mix_frame_count_)
 	{
 		const int decoded_count = audio_decoder->decode_frames(src_samples, mix_frame_count_ - frame_offset);
 		if (decoded_count == 0)
 		{
-			if (!voice.is_looping || !audio_decoder->rewind())
+			if (!voice.is_looping || is_rewound || !audio_decoder->rewind())
 			{
 				voice.is_active = false;
 				break;
 			}
+			is_rewound = true;
 			continue;
 		}
+		is_rewound = false;
 		float* const dst_samples = &r3s_samples_f32_mix_[frame_offset * 2];
 		if (channel_count == 1)
 		{

--- a/src/bstone/src/bstone_oal_audio_mixer.cpp
+++ b/src/bstone/src/bstone_oal_audio_mixer.cpp
@@ -895,16 +895,13 @@ int OalAudioMixer::get_max_voice_count()
 	using OalSourceResources = std::array<OalSourceResource, voices_limit>;
 	OalSourceResources oal_source_resources{};
 	int voice_count = 0;
-	try
+	for (OalSourceResource& oal_source_resource : oal_source_resources)
 	{
-		for (auto& oal_source_resource : oal_source_resources)
-		{
-			oal_source_resource = make_oal_source();
-			++voice_count;
-		}
+		oal_source_resource = make_oal_source();
+		if (oal_source_resource.is_empty())
+			break;
+		++voice_count;
 	}
-	catch (...)
-	{}
 	return voice_count;
 }
 

--- a/src/bstone/src/bstone_oal_audio_mixer.cpp
+++ b/src/bstone/src/bstone_oal_audio_mixer.cpp
@@ -1880,6 +1880,10 @@ void OalAudioMixer::r3s_update_oal_source()
 
 void OalAudioMixer::mix_r3s()
 {
+	// The mixing buffer is allocated only when the source is ready for it, so
+	// without a source there is nothing to mix into.
+	if (!r3s_sound_.is_initialized || !r3s_oal_source_.is_open())
+		return;
 	const int max_frames = mix_frame_count_ * oal_source_max_streaming_buffers;
 	while (r3s_sound_.queue_size < oal_source_max_streaming_buffers)
 	{

--- a/src/bstone/src/bstone_oal_resource.cpp
+++ b/src/bstone/src/bstone_oal_resource.cpp
@@ -82,8 +82,9 @@ OalSourceResource make_oal_source()
 {
 	BSTONE_ASSERT(alGenSources != nullptr);
 	ALuint al_source = 0;
+	// A driver runs out of sources sooner or later - the callers probe for that
+	// limit on purpose - so an empty result is a normal outcome, not a bug.
 	alGenSources(1, &al_source);
-	BSTONE_ASSERT(al_source != 0);
 	return OalSourceResource{al_source};
 }
 

--- a/src/bstone/src/bstone_system_audio_mixer.cpp
+++ b/src/bstone/src/bstone_system_audio_mixer.cpp
@@ -1115,7 +1115,9 @@ void SystemAudioMixer::handle_play_sound_command(const Command& command)
 		});
 	CacheItem* const cache_item = initialize_cache_item(play_sound_param);
 	if (cache_item == nullptr)
+	{
 		return;
+	}
 	for (Voice& i_voice : voices_)
 	{
 		if (!i_voice.is_active)
@@ -1155,7 +1157,9 @@ auto SystemAudioMixer::initialize_cache_item(const PlaySoundCommandParam& comman
 	}
 	cache_item = get_cache_item(command_param.sound_type, command_param.sound_index);
 	if (cache_item == nullptr)
+	{
 		return nullptr;
+	}
 	const bool is_opl_music = (command_param.sound_type == SoundType::opl_music);
 	if (cache_item->is_active)
 	{
@@ -1196,7 +1200,9 @@ auto SystemAudioMixer::initialize_ext_cache_item(const PlaySoundCommandParam& co
 {
 	CacheItem* const cache_item = get_ext_cache_item(command_param.sound_type, command_param.sound_index);
 	if (cache_item == nullptr)
+	{
 		return nullptr;
+	}
 	const bool is_opl_music = (command_param.sound_type == SoundType::opl_music);
 	if (cache_item->is_active)
 	{
@@ -1277,7 +1283,9 @@ bool SystemAudioMixer::decode_voice(const Voice& voice)
 {
 	CacheItem* const cache_item = voice.cache;
 	if (cache_item == nullptr)
+	{
 		return false;
+	}
 	if (!cache_item->is_active)
 		return false;
 	if (cache_item->is_invalid)

--- a/src/bstone/src/bstone_system_audio_mixer.cpp
+++ b/src/bstone/src/bstone_system_audio_mixer.cpp
@@ -1154,6 +1154,8 @@ auto SystemAudioMixer::initialize_cache_item(const PlaySoundCommandParam& comman
 			return cache_item;
 	}
 	cache_item = get_cache_item(command_param.sound_type, command_param.sound_index);
+	if (cache_item == nullptr)
+		return nullptr;
 	const bool is_opl_music = (command_param.sound_type == SoundType::opl_music);
 	if (cache_item->is_active)
 	{
@@ -1193,6 +1195,8 @@ auto SystemAudioMixer::initialize_cache_item(const PlaySoundCommandParam& comman
 auto SystemAudioMixer::initialize_ext_cache_item(const PlaySoundCommandParam& command_param) -> CacheItem*
 {
 	CacheItem* const cache_item = get_ext_cache_item(command_param.sound_type, command_param.sound_index);
+	if (cache_item == nullptr)
+		return nullptr;
 	const bool is_opl_music = (command_param.sound_type == SoundType::opl_music);
 	if (cache_item->is_active)
 	{

--- a/src/bstone/src/bstone_system_audio_mixer.cpp
+++ b/src/bstone/src/bstone_system_audio_mixer.cpp
@@ -38,7 +38,7 @@ class SystemAudioMixer final : public AudioMixer
 {
 public:
 	SystemAudioMixer(const AudioMixerInitParam& param);
-	~SystemAudioMixer() override = default;
+	~SystemAudioMixer() override;
 
 	OplEmulatorType get_opl_emulator_type() const override;
 	int get_rate() const override;
@@ -458,6 +458,14 @@ try
 	audio_device->pause(false);
 	sys_audio_device_.swap(audio_device);
 } BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
+
+SystemAudioMixer::~SystemAudioMixer()
+{
+	// Closing the device waits for an in-flight callback, and that callback
+	// reads and writes most of the other members. Do it before any of them is
+	// destroyed rather than relying on the declaration order.
+	sys_audio_device_ = nullptr;
+}
 
 OplEmulatorType SystemAudioMixer::get_opl_emulator_type() const
 {

--- a/src/bstone/src/bstone_system_audio_mixer.cpp
+++ b/src/bstone/src/bstone_system_audio_mixer.cpp
@@ -1219,6 +1219,11 @@ void SystemAudioMixer::cache_music(const Voice& voice)
 	CacheItem& cache_item = *voice.cache;
 	const int channel_count = cache_item.decoder->get_channel_count();
 	cache_item.frame_count = 0;
+	// A decoder with no decodable content - an empty OPL command block, an
+	// external file with no sample data - keeps returning no frames while
+	// happily rewinding. Give up once a rewind fails to make progress instead
+	// of retrying it forever on the audio thread.
+	bool is_rewound = false;
 	while (cache_item.frame_count < mix_frame_count_)
 	{
 		const int decoded_frame_count = cache_item.decoder->decode_frames(
@@ -1227,14 +1232,16 @@ void SystemAudioMixer::cache_music(const Voice& voice)
 		cache_item.frame_count += decoded_frame_count;
 		if (decoded_frame_count == 0)
 		{
-			if (voice.is_looping)
+			if (voice.is_looping && !is_rewound)
 			{
 				if (!cache_item.decoder->rewind())
 					break;
+				is_rewound = true;
 				continue;
 			}
 			break;
 		}
+		is_rewound = false;
 	}
 }
 

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -38,7 +38,6 @@ target_link_libraries(bstone_tests
 		${CMAKE_DL_LIBS}
 		bstone::lib::dr_flac
 			bstone::lib::nuked_opl3
-		bstone::lib::nuked_opl3
 		bstone::lib::sdl
 		bstone::lib::stb_vorbis
 		bstone::lib::zlib
@@ -112,10 +111,6 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_audio_decoder.h
 		../../../bstone/src/bstone_audio_sample_converter.cpp
 		../../../bstone/src/bstone_audio_sample_converter.h
-		../../../bstone/src/bstone_opl_emulator.cpp
-		../../../bstone/src/bstone_opl_emulator.h
-		../../../bstone/src/bstone_memory_binary_reader.cpp
-		../../../bstone/src/bstone_memory_binary_reader.h
 		../../../bstone/src/bstone_opl_emulator.cpp
 		../../../bstone/src/bstone_opl_emulator.h
 		../../../bstone/src/bstone_opl_utility.cpp

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -118,8 +118,6 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_memory_binary_reader.h
 		../../../bstone/src/bstone_opl_emulator.cpp
 		../../../bstone/src/bstone_opl_emulator.h
-		../../../bstone/src/bstone_opl_music_decoder.cpp
-		../../../bstone/src/bstone_opl_music_decoder.h
 		../../../bstone/src/bstone_opl_utility.cpp
 		../../../bstone/src/bstone_opl_utility.h
 		../../../bstone/src/bstone_dbopl_emulator.cpp
@@ -134,6 +132,8 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_pc_speaker_audio_decoder.h
 		../../../bstone/src/bstone_opl_sfx_decoder.cpp
 		../../../bstone/src/bstone_opl_sfx_decoder.h
+		../../../bstone/src/bstone_opl_music_decoder.cpp
+		../../../bstone/src/bstone_opl_music_decoder.h
 	PRIVATE
 		src/bstone_tests_ascii.cpp
 		src/bstone_tests_char_conv.cpp

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(bstone_tests
 		${CMAKE_DL_LIBS}
 		bstone::lib::dr_flac
 			bstone::lib::nuked_opl3
+		bstone::lib::nuked_opl3
 		bstone::lib::sdl
 		bstone::lib::stb_vorbis
 		bstone::lib::zlib
@@ -113,6 +114,12 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_audio_sample_converter.h
 		../../../bstone/src/bstone_opl_emulator.cpp
 		../../../bstone/src/bstone_opl_emulator.h
+		../../../bstone/src/bstone_memory_binary_reader.cpp
+		../../../bstone/src/bstone_memory_binary_reader.h
+		../../../bstone/src/bstone_opl_emulator.cpp
+		../../../bstone/src/bstone_opl_emulator.h
+		../../../bstone/src/bstone_opl_music_decoder.cpp
+		../../../bstone/src/bstone_opl_music_decoder.h
 		../../../bstone/src/bstone_opl_utility.cpp
 		../../../bstone/src/bstone_opl_utility.h
 		../../../bstone/src/bstone_dbopl_emulator.cpp
@@ -154,6 +161,7 @@ target_sources(bstone_tests
 		src/bstone_tests_memory_binary_reader.cpp
 		src/bstone_tests_pc_speaker_audio_decoder.cpp
 		src/bstone_tests_opl_sfx_decoder.cpp
+		src/bstone_tests_opl_music_decoder.cpp
 	PRIVATE
 		src/bstone_tester.cpp
 		src/bstone_tester.h

--- a/src/tests/src/tests/src/bstone_tests_opl_music_decoder.cpp
+++ b/src/tests/src/tests/src/bstone_tests_opl_music_decoder.cpp
@@ -1,0 +1,172 @@
+#include <cstdint>
+
+#include <initializer_list>
+#include <vector>
+
+#include "bstone_audio_decoder.h"
+#include "bstone_opl_music_decoder.h"
+#include "bstone_tester.h"
+
+namespace {
+
+auto tester = bstone::Tester{};
+
+// ==========================================================================
+
+constexpr auto dst_rate = 44100;
+
+// An OPL music chunk is a little-endian u16 with the size of the command block
+// in bytes, followed by that many bytes of four-byte commands: a register
+// address, a register value and a little-endian u16 delay in ticks.
+using Chunk = std::vector<std::uint8_t>;
+
+Chunk make_chunk(int command_block_size, std::initializer_list<std::uint8_t> commands)
+{
+	auto chunk = Chunk{};
+	chunk.push_back(static_cast<std::uint8_t>(command_block_size & 0xFF));
+	chunk.push_back(static_cast<std::uint8_t>((command_block_size >> 8) & 0xFF));
+	chunk.insert(chunk.end(), commands);
+	return chunk;
+}
+
+bstone::AudioDecoderUPtr make_decoder(const Chunk& chunk)
+{
+	auto decoder = bstone::make_opl_music_audio_decoder(bstone::OplEmulatorType::dbopl);
+
+	const auto param = bstone::AudioDecoderInitParam
+	{
+		.vfs_stream = bstone::VfsInputStreamUPtr{},
+		.src_raw_data = chunk.data(),
+		.src_raw_size = static_cast<int>(chunk.size()),
+		.dst_rate = dst_rate};
+
+	if (!decoder->initialize(param))
+	{
+		return nullptr;
+	}
+
+	return decoder;
+}
+
+// ==========================================================================
+
+// bool initialize(const AudioDecoderInitParam&)
+// Too small for the command block size.
+void test_q7m2vh4nx8ktz3pd()
+{
+	const auto chunk = Chunk{0x00};
+	const auto decoder = make_decoder(chunk);
+	tester.check(decoder == nullptr);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// The command block size is not a multiple of the command size.
+void test_w9c5rj1bstn6yl0a()
+{
+	const auto chunk = make_chunk(3, {0x01, 0x20, 0x00});
+	const auto decoder = make_decoder(chunk);
+	tester.check(decoder == nullptr);
+}
+
+// bool initialize(const AudioDecoderInitParam&)
+// The command block is shorter than its declared size.
+void test_e3g8kd7pqvxm2r5h()
+{
+	const auto chunk = make_chunk(8, {0x01, 0x20, 0x01, 0x00});
+	const auto decoder = make_decoder(chunk);
+	tester.check(decoder == nullptr);
+}
+
+// ==========================================================================
+
+// int decode_frames(float*, int)
+void test_t6nz0aw4cufj9bs1()
+{
+	const auto chunk = make_chunk(4, {0x01, 0x20, 0x01, 0x00});
+	const auto decoder = make_decoder(chunk);
+
+	if (decoder == nullptr)
+	{
+		tester.check(false);
+		return;
+	}
+
+	constexpr auto max_frames = 1024;
+	auto samples = std::vector<float>(max_frames * decoder->get_channel_count());
+	const auto decoded_frame_count = decoder->decode_frames(samples.data(), max_frames);
+	tester.check(decoded_frame_count > 0);
+}
+
+// int decode_frames(float*, int)
+// An empty command block decodes nothing, yet rewinding it succeeds. A mixer
+// that keeps retrying such a decoder never makes progress.
+void test_y2xl5mp8dhqk7v3g()
+{
+	const auto chunk = make_chunk(0, {});
+	const auto decoder = make_decoder(chunk);
+
+	if (decoder == nullptr)
+	{
+		tester.check(false);
+		return;
+	}
+
+	constexpr auto max_frames = 1024;
+	auto samples = std::vector<float>(max_frames * decoder->get_channel_count());
+	const auto first_count = decoder->decode_frames(samples.data(), max_frames);
+	const auto is_rewound = decoder->rewind();
+	const auto second_count = decoder->decode_frames(samples.data(), max_frames);
+	tester.check(first_count == 0 && is_rewound && second_count == 0);
+}
+
+// int decode_frames(float*, int)
+// Commands without a delay produce no frames either.
+void test_u4bs9tr1nwce6zj0()
+{
+	const auto chunk = make_chunk(8, {0x01, 0x20, 0x00, 0x00, 0x02, 0x40, 0x00, 0x00});
+	const auto decoder = make_decoder(chunk);
+
+	if (decoder == nullptr)
+	{
+		tester.check(false);
+		return;
+	}
+
+	constexpr auto max_frames = 1024;
+	auto samples = std::vector<float>(max_frames * decoder->get_channel_count());
+	const auto first_count = decoder->decode_frames(samples.data(), max_frames);
+	const auto is_rewound = decoder->rewind();
+	const auto second_count = decoder->decode_frames(samples.data(), max_frames);
+	tester.check(first_count == 0 && is_rewound && second_count == 0);
+}
+
+// ==========================================================================
+
+class Registrator
+{
+public:
+	Registrator()
+	{
+		register_initialize();
+		register_decode_frames();
+	}
+
+private:
+	void register_initialize()
+	{
+		tester.register_test("OplMusicDecoder#q7m2vh4nx8ktz3pd", test_q7m2vh4nx8ktz3pd);
+		tester.register_test("OplMusicDecoder#w9c5rj1bstn6yl0a", test_w9c5rj1bstn6yl0a);
+		tester.register_test("OplMusicDecoder#e3g8kd7pqvxm2r5h", test_e3g8kd7pqvxm2r5h);
+	}
+
+	void register_decode_frames()
+	{
+		tester.register_test("OplMusicDecoder#t6nz0aw4cufj9bs1", test_t6nz0aw4cufj9bs1);
+		tester.register_test("OplMusicDecoder#y2xl5mp8dhqk7v3g", test_y2xl5mp8dhqk7v3g);
+		tester.register_test("OplMusicDecoder#u4bs9tr1nwce6zj0", test_u4bs9tr1nwce6zj0);
+	}
+};
+
+auto registrator = Registrator{};
+
+} // namespace


### PR DESCRIPTION
From a correctness review of wip, with several found by running the game.

- Close the audio device before the state its callback uses — the callback could run against members already destroyed during shutdown
- Honour the null result of the cache item lookup
- Stop retrying a music decoder that never yields frames — in both mixers, a decoder with no decodable content rewound happily forever on the audio thread
- Detect the real OpenAL source limit again, and do not mix 3D stereo without a source for it

Adds coverage for the OPL music decoder.

Related to #560: "Do not mix 3D stereo without a source for it" is a fix in the 3D-stereo path that issue is about, not a change to what it does. A stereo sound still plays as stereo rather than being downmixed; it just no longer mixes into a buffer that was never allocated because the source for it does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

