### PR TITLE
Fix GL screenshots on the MSAA and ES 2.0 paths

### DIFF
--- a/src/bstone/src/bstone_gl_r3r.cpp
+++ b/src/bstone/src/bstone_gl_r3r.cpp
@@ -508,8 +508,14 @@ try {
 	is_flipped_vertically = true;
 	bind_framebuffers_for_read_pixels();
 
-	glReadBuffer(GL_BACK);
-	GlR3rError::ensure_no_errors();
+	// OpenGL ES gained glReadBuffer only in 3.0, so on the ES 2.0 path the
+	// symbol may well be missing. Nothing is lost: the back buffer is the
+	// default read buffer of the default framebuffer anyway.
+	if (glReadBuffer != nullptr)
+	{
+		glReadBuffer(GL_BACK);
+		GlR3rError::ensure_no_errors();
+	}
 
 	// The destination rows are tightly packed, unlike the four byte row
 	// alignment OpenGL packs into by default.

--- a/src/bstone/src/bstone_gl_r3r.cpp
+++ b/src/bstone/src/bstone_gl_r3r.cpp
@@ -275,7 +275,6 @@ try
 			{
 				window_param.aa_type = R3rAaType::none;
 				window_param.aa_value = 0;
-				window_param.is_default_depth_buffer_disabled = true;
 			}
 		}
 		else

--- a/src/bstone/src/bstone_gl_r3r.cpp
+++ b/src/bstone/src/bstone_gl_r3r.cpp
@@ -1016,6 +1016,12 @@ try {
 		return;
 	}
 
+	// The frame that was just submitted is still sitting in the MSAA
+	// framebuffer. Resolving it here rather than waiting for the presentation
+	// keeps the screenshot from picking up whatever the default framebuffer
+	// was left with by the previous buffer swap.
+	blit_framebuffers();
+
 	bind_framebuffer(GL_FRAMEBUFFER, 0);
 } BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
 

--- a/src/bstone/src/bstone_gl_r3r.cpp
+++ b/src/bstone/src/bstone_gl_r3r.cpp
@@ -58,6 +58,7 @@ public:
 
 	sys::Window& get_window() const override;
 	void handle_resize(sys::WindowSize new_size) override;
+	sys::WindowSize get_screen_size() const override;
 
 	bool get_vsync() const override;
 	void enable_vsync(bool is_enabled) override;
@@ -65,8 +66,7 @@ public:
 	void set_anti_aliasing(R3rAaType aa_type, int aa_value) override;
 
 	void read_pixels(
-		sys::PixelFormat pixel_format,
-		void* buffer,
+		const R3rReadPixelsParam& param,
 		bool& is_flipped_vertically) override;
 
 	void present() override;
@@ -429,6 +429,11 @@ try {
 	}
 } BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
 
+sys::WindowSize GlR3rImpl::get_screen_size() const
+{
+	return sys::WindowSize{screen_width_, screen_height_};
+}
+
 bool GlR3rImpl::get_vsync() const
 {
 	if (!device_features_.is_vsync_available)
@@ -495,27 +500,26 @@ try {
 } BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
 
 void GlR3rImpl::read_pixels(
-	sys::PixelFormat pixel_format,
-	void* buffer,
+	const R3rReadPixelsParam& param,
 	bool& is_flipped_vertically)
 try {
-	BSTONE_ASSERT(buffer != nullptr);
-
-	switch (pixel_format)
-	{
-		case sys::PixelFormat::r8g8b8:
-			break;
-
-		default: BSTONE_THROW_STATIC_SOURCE("Unsupported pixel format.");
-	}
+	r3r_validate_read_pixels_param(param, screen_width_, screen_height_);
 
 	is_flipped_vertically = true;
 	bind_framebuffers_for_read_pixels();
 
 	glReadBuffer(GL_BACK);
 	GlR3rError::ensure_no_errors();
-  
-	glReadPixels(0, 0, screen_width_, screen_height_, GL_RGB, GL_UNSIGNED_BYTE, buffer);
+
+	// The destination rows are tightly packed, unlike the four byte row
+	// alignment OpenGL packs into by default.
+	glPixelStorei(GL_PACK_ALIGNMENT, 1);
+	GlR3rError::ensure_no_errors();
+
+	glReadPixels(0, 0, screen_width_, screen_height_, GL_RGB, GL_UNSIGNED_BYTE, param.buffer);
+	GlR3rError::ensure_no_errors();
+
+	glPixelStorei(GL_PACK_ALIGNMENT, 4);
 	GlR3rError::ensure_no_errors();
 
 	bind_framebuffers();

--- a/src/bstone/src/bstone_hw_video.cpp
+++ b/src/bstone/src/bstone_hw_video.cpp
@@ -54,11 +54,7 @@ public:
 	std::string_view get_renderer_name() override;
 	void clear_vga_buffer() override;
 
-	void take_screenshot(
-		int width,
-		int height,
-		int stride_rgb_888,
-		ScreenshotBuffer&& src_pixels_rgb_888) override;
+	void take_screenshot() override;
 
 	void vsync_present() override;
 	void present() override;
@@ -1521,23 +1517,32 @@ void HwVideo::clear_vga_buffer()
 {
 }
 
-void HwVideo::take_screenshot(
-	int width,
-	int height,
-	int stride_rgb_888,
-	ScreenshotBuffer&& src_pixels_rgb_888)
+void HwVideo::take_screenshot()
 try {
+	// The renderer knows how big the rendered image really is; the video mode
+	// cvars do not, because the window manager is free to hand out a drawable
+	// of some other size.
+	const sys::WindowSize screen_size = renderer_->get_screen_size();
+	const auto width = screen_size.width;
+	const auto height = screen_size.height;
+
+	auto src_pixels_rgb_888 = std::make_unique<std::uint8_t[]>(
+		static_cast<std::size_t>(3) * width * height);
+
 	auto is_flipped_vertically = false;
 
 	renderer_->read_pixels(
-		sys::PixelFormat::r8g8b8,
-		src_pixels_rgb_888.get(),
+		R3rReadPixelsParam{
+			.pixel_format = sys::PixelFormat::r8g8b8,
+			.width = width,
+			.height = height,
+			.buffer = src_pixels_rgb_888.get(),
+		},
 		is_flipped_vertically);
 
 	vid_schedule_save_screenshot_task(
 		width,
 		height,
-		stride_rgb_888,
 		std::move(src_pixels_rgb_888),
 		is_flipped_vertically
 	);

--- a/src/bstone/src/bstone_null_r3r.cpp
+++ b/src/bstone/src/bstone_null_r3r.cpp
@@ -41,6 +41,7 @@ public:
 
 	sys::Window& get_window() const override;
 	void handle_resize(sys::WindowSize new_size) override;
+	sys::WindowSize get_screen_size() const override;
 
 	bool get_vsync() const override;
 	void enable_vsync(bool is_enabled) override;
@@ -48,8 +49,7 @@ public:
 	void set_anti_aliasing(R3rAaType aa_type, int aa_value) override;
 
 	void read_pixels(
-		sys::PixelFormat pixel_format,
-		void* buffer,
+		const R3rReadPixelsParam& param,
 		bool& is_flipped_vertically) override;
 
 	void present() override;
@@ -130,6 +130,11 @@ sys::Window& NullR3rImpl::get_window() const
 void NullR3rImpl::handle_resize([[maybe_unused]] sys::WindowSize new_size)
 {}
 
+sys::WindowSize NullR3rImpl::get_screen_size() const
+{
+	return sys::WindowSize{};
+}
+
 bool NullR3rImpl::get_vsync() const
 {
 	return false;
@@ -142,8 +147,7 @@ void NullR3rImpl::set_anti_aliasing([[maybe_unused]] R3rAaType aa_type, [[maybe_
 {}
 
 void NullR3rImpl::read_pixels(
-	[[maybe_unused]] sys::PixelFormat pixel_format,
-	[[maybe_unused]] void* buffer,
+	[[maybe_unused]] const R3rReadPixelsParam& param,
 	[[maybe_unused]] bool& is_flipped_vertically)
 {}
 

--- a/src/bstone/src/bstone_r3r.h
+++ b/src/bstone/src/bstone_r3r.h
@@ -13,6 +13,8 @@ SPDX-License-Identifier: MIT
 #include <span>
 #include <string_view>
 
+#include "bstone_exception.h"
+
 #include "bstone_sys_pixel_format.h"
 #include "bstone_sys_window.h"
 
@@ -58,6 +60,45 @@ struct R3rDrawIndexedParam
 	int index_offset;
 };
 
+struct R3rReadPixelsParam
+{
+	// Pixel format of the destination.
+	sys::PixelFormat pixel_format;
+
+	// Width of the destination in pixels.
+	int width;
+
+	// Height of the destination in pixels.
+	int height;
+
+	// Destination buffer with tightly packed rows.
+	void* buffer;
+};
+
+// Throws unless the destination describes an image of exactly the specified
+// size. A renderer packs the rows on its own, so it can neither crop nor
+// re-pack them to fit a destination of some other size.
+inline void r3r_validate_read_pixels_param(
+	const R3rReadPixelsParam& param,
+	int width,
+	int height)
+{
+	if (param.pixel_format != sys::PixelFormat::r8g8b8)
+	{
+		BSTONE_THROW_STATIC_SOURCE("Unsupported pixel format.");
+	}
+
+	if (param.buffer == nullptr)
+	{
+		BSTONE_THROW_STATIC_SOURCE("Null destination buffer.");
+	}
+
+	if (param.width != width || param.height != height)
+	{
+		BSTONE_THROW_STATIC_SOURCE("Destination size mismatch.");
+	}
+}
+
 // ==========================================================================
 
 class R3r
@@ -78,14 +119,16 @@ public:
 	virtual sys::Window& get_window() const = 0;
 	virtual void handle_resize(sys::WindowSize new_size) = 0;
 
+	// Size of the rendered image in pixels.
+	virtual sys::WindowSize get_screen_size() const = 0;
+
 	virtual bool get_vsync() const = 0;
 	virtual void enable_vsync(bool is_enabled) = 0;
 
 	virtual void set_anti_aliasing(R3rAaType aa_type, int aa_value) = 0;
 
 	virtual void read_pixels(
-		sys::PixelFormat pixel_format,
-		void* buffer,
+		const R3rReadPixelsParam& param,
 		bool& is_flipped_vertically) = 0;
 
 	virtual void present() = 0;

--- a/src/bstone/src/bstone_r3r_utils.cpp
+++ b/src/bstone/src/bstone_r3r_utils.cpp
@@ -641,10 +641,7 @@ try {
 	gl_attributes.green_bit_count = 8;
 	gl_attributes.blue_bit_count = 8;
 
-	if (!param.is_default_depth_buffer_disabled)
-	{
-		gl_attributes.depth_bit_count = 16;
-	}
+	gl_attributes.depth_bit_count = 16;
 
 	switch (param.renderer_type)
 	{

--- a/src/bstone/src/bstone_r3r_utils.h
+++ b/src/bstone/src/bstone_r3r_utils.h
@@ -28,8 +28,6 @@ public:
 
 	R3rAaType aa_type;
 	int aa_value;
-
-	bool is_default_depth_buffer_disabled;
 };
 
 struct R3rUtilsSetWindowModeParam

--- a/src/bstone/src/bstone_sw_video.cpp
+++ b/src/bstone/src/bstone_sw_video.cpp
@@ -43,11 +43,7 @@ public:
 	bool is_hardware() const override;
 	std::string_view get_renderer_name() override;
 	void clear_vga_buffer() override;
-	void take_screenshot(
-		int width,
-		int height,
-		int stride_rgb_888,
-		ScreenshotBuffer&& src_pixels_rgb_888) override;
+	void take_screenshot() override;
 	void vsync_present() override;
 	void present() override;
 
@@ -232,18 +228,23 @@ try {
 	renderer_->set_viewport();
 } BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
 
-void SwVideo::take_screenshot(
-	int width,
-	int height,
-	int stride_rgb_888,
-	ScreenshotBuffer&& src_pixels_rgb_888)
+void SwVideo::take_screenshot()
 try {
-	renderer_->read_pixels(sys::PixelFormat::r8g8b8, src_pixels_rgb_888.get(), stride_rgb_888);
+	// The renderer knows how big the rendered image really is; the video mode
+	// cvars do not, because the window manager is free to hand out a drawable
+	// of some other size.
+	const sys::RendererOutputSize output_size = renderer_->get_output_size();
+	const auto width = output_size.width;
+	const auto height = output_size.height;
+
+	auto src_pixels_rgb_888 = std::make_unique<std::uint8_t[]>(
+		static_cast<std::size_t>(3) * width * height);
+
+	renderer_->read_pixels(sys::PixelFormat::r8g8b8, width, height, src_pixels_rgb_888.get());
 
 	vid_schedule_save_screenshot_task(
 		width,
 		height,
-		stride_rgb_888,
 		std::move(src_pixels_rgb_888),
 		false);
 } BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED

--- a/src/bstone/src/bstone_sys_renderer.h
+++ b/src/bstone/src/bstone_sys_renderer.h
@@ -30,6 +30,12 @@ struct RendererViewport : public Rect
 	using Rect::Rect;
 };
 
+struct RendererOutputSize
+{
+	int width;
+	int height;
+};
+
 // ======================================
 
 class Renderer
@@ -39,12 +45,20 @@ public:
 	virtual ~Renderer() = default;
 
 	virtual const char* get_name() const = 0;
+
+	// Size of the current rendering target in pixels.
+	virtual RendererOutputSize get_output_size() const = 0;
+
 	virtual void set_viewport() = 0;
 	virtual void clear() = 0;
 	virtual void set_draw_color(Color color) = 0;
 	virtual void fill(std::span<const FRect> rects) = 0;
 	virtual void present() = 0;
-	virtual void read_pixels(PixelFormat pixel_format, void* pixels, int pitch) = 0;
+
+	// Reads the rendering target into a buffer with tightly packed rows. The
+	// destination must be of exactly the same size as the target.
+	virtual void read_pixels(PixelFormat pixel_format, int width, int height, void* pixels) = 0;
+
 	virtual TextureUPtr make_texture(const TextureInitParam& param) = 0;
 };
 

--- a/src/bstone/src/bstone_sys_renderer_sdl.cpp
+++ b/src/bstone/src/bstone_sys_renderer_sdl.cpp
@@ -57,12 +57,13 @@ public:
 	~RendererSdl() override;
 
 	const char* get_name() const override;
+	RendererOutputSize get_output_size() const override;
 	void set_viewport() override;
 	void clear() override;
 	void set_draw_color(Color color) override;
 	void fill(std::span<const FRect> rects) override;
 	void present() override;
-	void read_pixels(PixelFormat pixel_format, void* pixels, int pitch) override;
+	void read_pixels(PixelFormat pixel_format, int width, int height, void* pixels) override;
 	TextureUPtr make_texture(const TextureInitParam& param) override;
 
 private:
@@ -118,6 +119,17 @@ const char* RendererSdl::get_name() const
 	return SDL_GetStringProperty(sdl_properties_id, SDL_PROP_RENDERER_NAME_STRING, "");
 }
 
+RendererOutputSize RendererSdl::get_output_size() const
+{
+	int width;
+	int height;
+	if (!SDL_GetCurrentRenderOutputSize(sdl_renderer_, &width, &height))
+	{
+		sdl::fail("SDL_GetCurrentRenderOutputSize");
+	}
+	return RendererOutputSize{width, height};
+}
+
 void RendererSdl::set_viewport()
 {
 	if (!SDL_SetRenderViewport(sdl_renderer_, nullptr))
@@ -165,11 +177,15 @@ void RendererSdl::present()
 	}
 }
 
-void RendererSdl::read_pixels(PixelFormat pixel_format, void* pixels, int pitch)
+void RendererSdl::read_pixels(PixelFormat pixel_format, int width, int height, void* pixels)
 {
 	if (pixel_format != PixelFormat::r8g8b8)
 	{
 		BSTONE_THROW_STATIC_SOURCE("Unsupported destination pixel format.");
+	}
+	if (pixels == nullptr)
+	{
+		BSTONE_THROW_STATIC_SOURCE("Null destination buffer.");
 	}
 	SDL_Surface* sdl_surface = SDL_RenderReadPixels(sdl_renderer_, nullptr);
 	if (sdl_surface == nullptr)
@@ -181,6 +197,12 @@ void RendererSdl::read_pixels(PixelFormat pixel_format, void* pixels, int pitch)
 		{
 			SDL_DestroySurface(sdl_surface);
 		});
+	// The whole target is converted in one go, so anything but an exact match
+	// would run past the end of the destination.
+	if (sdl_surface->w != width || sdl_surface->h != height)
+	{
+		BSTONE_THROW_STATIC_SOURCE("Destination size mismatch.");
+	}
 	if (SDL_MUSTLOCK(sdl_surface))
 	{
 		if (!SDL_LockSurface(sdl_surface))
@@ -196,7 +218,7 @@ void RendererSdl::read_pixels(PixelFormat pixel_format, void* pixels, int pitch)
 		sdl_surface->pitch,
 		SDL_PIXELFORMAT_RGB24,
 		pixels,
-		pitch))
+		3 * width))
 	{
 		sdl::fail("SDL_ConvertPixels");
 	}

--- a/src/bstone/src/bstone_video.h
+++ b/src/bstone/src/bstone_video.h
@@ -38,11 +38,7 @@ public:
 
 	virtual void clear_vga_buffer() = 0;
 
-	virtual void take_screenshot(
-		int width,
-		int height,
-		int stride_rgb_888,
-		ScreenshotBuffer&& src_pixels_rgb_888) = 0;
+	virtual void take_screenshot() = 0;
 
 	virtual void vsync_present() = 0;
 	virtual void present() = 0;

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -63,6 +63,7 @@ public:
 
 	sys::Window& get_window() const override;
 	void handle_resize(sys::WindowSize new_size) override;
+	sys::WindowSize get_screen_size() const override;
 
 	bool get_vsync() const override;
 	void enable_vsync(bool is_enabled) override;
@@ -70,8 +71,7 @@ public:
 	void set_anti_aliasing(R3rAaType aa_type, int aa_value) override;
 
 	void read_pixels(
-		sys::PixelFormat pixel_format,
-		void* buffer,
+		const R3rReadPixelsParam& param,
 		bool& is_flipped_vertically) override;
 
 	void present() override;
@@ -369,6 +369,13 @@ try
 }
 BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
 
+sys::WindowSize VkR3rImpl::get_screen_size() const
+{
+	return sys::WindowSize{
+		static_cast<int>(context_.vk_offscreen_width),
+		static_cast<int>(context_.vk_offscreen_height)};
+}
+
 bool VkR3rImpl::get_vsync() const
 {
 	return context_.vk_present_mode_khr == VK_PRESENT_MODE_FIFO_KHR;
@@ -403,14 +410,13 @@ void VkR3rImpl::set_anti_aliasing(R3rAaType aa_type, int aa_value)
 }
 
 void VkR3rImpl::read_pixels(
-	sys::PixelFormat pixel_format,
-	void* buffer,
+	const R3rReadPixelsParam& param,
 	bool& is_flipped_vertically)
 {
-	if (pixel_format != sys::PixelFormat::r8g8b8)
-	{
-		BSTONE_THROW_STATIC_SOURCE("Unsupported pixel format.");
-	}
+	r3r_validate_read_pixels_param(
+		param,
+		static_cast<int>(context_.vk_offscreen_width),
+		static_cast<int>(context_.vk_offscreen_height));
 	if (context_.surface_format != VK_FORMAT_R8G8B8A8_UNORM &&
 		context_.surface_format != VK_FORMAT_B8G8R8A8_UNORM)
 	{
@@ -544,7 +550,7 @@ void VkR3rImpl::read_pixels(
 			std::uint8_t a;
 		};
 		const RgbaPixel* const rgba_pixels = reinterpret_cast<const RgbaPixel*>(intermediate_pixels);
-		RgbPixel* const rgb_pixels = static_cast<RgbPixel*>(buffer);
+		RgbPixel* const rgb_pixels = static_cast<RgbPixel*>(param.buffer);
 		for (std::size_t i_pixel = 0; i_pixel < pixel_count; ++i_pixel)
 		{
 			const RgbaPixel& rgba_pixel = rgba_pixels[i_pixel];
@@ -565,7 +571,7 @@ void VkR3rImpl::read_pixels(
 		};
 
 		const BgraPixel* bgra_pixels = reinterpret_cast<const BgraPixel*>(intermediate_pixels);
-		RgbPixel* const rgb_pixels = static_cast<RgbPixel*>(buffer);
+		RgbPixel* const rgb_pixels = static_cast<RgbPixel*>(param.buffer);
 		for (std::size_t i_pixel = 0; i_pixel < pixel_count; ++i_pixel)
 		{
 			const BgraPixel& bgra_pixel = bgra_pixels[i_pixel];

--- a/src/bstone/src/id_vl.cpp
+++ b/src/bstone/src/id_vl.cpp
@@ -455,7 +455,6 @@ public:
 	void reset(
 		int width,
 		int height,
-		int stride_rgb_888,
 		ScreenshotBuffer&& src_pixels_rgb_888,
 		bool is_flipped_vertically);
 
@@ -467,7 +466,6 @@ private:
 
 	int width_{};
 	int height_{};
-	int stride_rgb_888_{};
 	ScreenshotBuffer src_pixels_rgb_888_{};
 	bool is_flipped_vertically_{};
 }; // SaveScreenshotMtTask
@@ -512,28 +510,32 @@ try
 
 	vid_log("Taking screenshot \"" + path + "\".");
 
+	// The image encoder expects tightly packed rows, so that is what the
+	// renderers are asked to produce.
+	const auto stride_rgb_888 = 3 * width_;
+
 	if (is_flipped_vertically_)
 	{
-		auto row_buffer = std::make_unique<std::uint8_t[]>(stride_rgb_888_);
+		auto row_buffer = std::make_unique<std::uint8_t[]>(stride_rgb_888);
 		auto tmp_row = row_buffer.get();
 
 		const auto half_height = height_ / 2;
 
 		auto src_row = src_pixels_rgb_888_.get();
-		auto dst_row = src_row + (stride_rgb_888_ * (height_ - 1));
+		auto dst_row = src_row + (stride_rgb_888 * (height_ - 1));
 
 		for (auto h = 0; h < half_height; ++h)
 		{
-			std::copy_n(src_row, stride_rgb_888_, tmp_row);
-			std::copy_n(dst_row, stride_rgb_888_, src_row);
-			std::copy_n(tmp_row, stride_rgb_888_, dst_row);
+			std::copy_n(src_row, stride_rgb_888, tmp_row);
+			std::copy_n(dst_row, stride_rgb_888, src_row);
+			std::copy_n(tmp_row, stride_rgb_888, dst_row);
 
-			src_row += stride_rgb_888_;
-			dst_row -= stride_rgb_888_;
+			src_row += stride_rgb_888;
+			dst_row -= stride_rgb_888;
 		}
 	}
 
-	const auto max_dst_buffer_size = stride_rgb_888_ * height_;
+	const auto max_dst_buffer_size = stride_rgb_888 * height_;
 	auto dst_buffer = std::make_unique<std::uint8_t[]>(max_dst_buffer_size);
 	auto image_encoder = bstone::make_image_encoder(bstone::ImageEncoderType::png);
 
@@ -599,7 +601,6 @@ void SaveScreenshotMtTask::set_failed(
 void SaveScreenshotMtTask::reset(
 	int width,
 	int height,
-	int stride_rgb_888,
 	ScreenshotBuffer&& src_pixels_rgb_888,
 	bool is_flipped_vertically)
 {
@@ -609,7 +610,6 @@ void SaveScreenshotMtTask::reset(
 
 	width_ = width;
 	height_ = height;
-	stride_rgb_888_ = stride_rgb_888;
 	src_pixels_rgb_888_ = std::move(src_pixels_rgb_888);
 	is_flipped_vertically_ = is_flipped_vertically;
 }
@@ -1290,7 +1290,6 @@ try {
 void vid_schedule_save_screenshot_task(
 	int width,
 	int height,
-	int stride_rgb_888,
 	ScreenshotBuffer&& src_pixels_rgb_888,
 	bool is_flipped_vertically)
 try {
@@ -1301,7 +1300,6 @@ try {
 			task.reset(
 				width,
 				height,
-				stride_rgb_888,
 				std::move(src_pixels_rgb_888),
 				is_flipped_vertically
 			);
@@ -1322,17 +1320,7 @@ try
 {
 	vid_is_take_screenshot_scheduled = false;
 
-	const auto width = vid_cfg_get_width();
-	const auto height = vid_cfg_get_height();
-	const auto stride_rgb_888 = (((3 * width) + 3) / 4) * 4;
-	auto src_rgb_888_pixels = std::make_unique<std::uint8_t[]>(stride_rgb_888 * height);
-
-	g_video->take_screenshot(
-		width,
-		height,
-		stride_rgb_888,
-		std::move(src_rgb_888_pixels)
-	);
+	g_video->take_screenshot();
 }
 catch (const std::exception& ex)
 {

--- a/src/bstone/src/id_vl.h
+++ b/src/bstone/src/id_vl.h
@@ -554,7 +554,6 @@ void vid_schedule_take_screenshot();
 void vid_schedule_save_screenshot_task(
 	int width,
 	int height,
-	int stride_rgb_888,
 	ScreenshotBuffer&& src_pixels_rgb_888,
 	bool is_flipped_vertically);
 

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -129,6 +129,7 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_opl_sfx_decoder.h
 		../../../bstone/src/bstone_opl_music_decoder.cpp
 		../../../bstone/src/bstone_opl_music_decoder.h
+		../../../bstone/src/bstone_r3r.h
 	PRIVATE
 		src/bstone_tests_ascii.cpp
 		src/bstone_tests_char_conv.cpp
@@ -157,6 +158,7 @@ target_sources(bstone_tests
 		src/bstone_tests_pc_speaker_audio_decoder.cpp
 		src/bstone_tests_opl_sfx_decoder.cpp
 		src/bstone_tests_opl_music_decoder.cpp
+		src/bstone_tests_r3r.cpp
 	PRIVATE
 		src/bstone_tester.cpp
 		src/bstone_tester.h

--- a/src/tests/src/tests/src/bstone_tests_r3r.cpp
+++ b/src/tests/src/tests/src/bstone_tests_r3r.cpp
@@ -1,0 +1,181 @@
+#include <cstdint>
+
+#include "bstone_r3r.h"
+#include "bstone_tester.h"
+
+namespace {
+
+auto tester = bstone::Tester{};
+
+std::uint8_t buffer[3 * 4 * 2];
+
+// ==========================================================================
+
+// void r3r_validate_read_pixels_param(const R3rReadPixelsParam&, int, int)
+void test_togn86jyn8b42a2p()
+{
+	const auto param = bstone::R3rReadPixelsParam{
+		.pixel_format = bstone::sys::PixelFormat::r8g8b8,
+		.width = 4,
+		.height = 2,
+		.buffer = buffer};
+
+	auto is_failed = false;
+
+	try
+	{
+		bstone::r3r_validate_read_pixels_param(param, 4, 2);
+	}
+	catch (...)
+	{
+		is_failed = true;
+	}
+
+	tester.check(!is_failed);
+}
+
+// void r3r_validate_read_pixels_param(const R3rReadPixelsParam&, int, int)
+// Unsupported pixel format.
+void test_2xzgqvr59z3omnta()
+{
+	const auto param = bstone::R3rReadPixelsParam{
+		.pixel_format = bstone::sys::PixelFormat::b8g8r8a8,
+		.width = 4,
+		.height = 2,
+		.buffer = buffer};
+
+	auto is_failed = false;
+
+	try
+	{
+		bstone::r3r_validate_read_pixels_param(param, 4, 2);
+	}
+	catch (...)
+	{
+		is_failed = true;
+	}
+
+	tester.check(is_failed);
+}
+
+// void r3r_validate_read_pixels_param(const R3rReadPixelsParam&, int, int)
+// Null buffer.
+void test_63kn34qkp1o6p160()
+{
+	const auto param = bstone::R3rReadPixelsParam{
+		.pixel_format = bstone::sys::PixelFormat::r8g8b8,
+		.width = 4,
+		.height = 2,
+		.buffer = nullptr};
+
+	auto is_failed = false;
+
+	try
+	{
+		bstone::r3r_validate_read_pixels_param(param, 4, 2);
+	}
+	catch (...)
+	{
+		is_failed = true;
+	}
+
+	tester.check(is_failed);
+}
+
+// void r3r_validate_read_pixels_param(const R3rReadPixelsParam&, int, int)
+// Destination narrower than the image.
+void test_0w65hpbd2w0u877t()
+{
+	const auto param = bstone::R3rReadPixelsParam{
+		.pixel_format = bstone::sys::PixelFormat::r8g8b8,
+		.width = 4,
+		.height = 2,
+		.buffer = buffer};
+
+	auto is_failed = false;
+
+	try
+	{
+		bstone::r3r_validate_read_pixels_param(param, 8, 2);
+	}
+	catch (...)
+	{
+		is_failed = true;
+	}
+
+	tester.check(is_failed);
+}
+
+// void r3r_validate_read_pixels_param(const R3rReadPixelsParam&, int, int)
+// Destination wider than the image.
+void test_6036ue7dgnn36t8z()
+{
+	const auto param = bstone::R3rReadPixelsParam{
+		.pixel_format = bstone::sys::PixelFormat::r8g8b8,
+		.width = 4,
+		.height = 2,
+		.buffer = buffer};
+
+	auto is_failed = false;
+
+	try
+	{
+		bstone::r3r_validate_read_pixels_param(param, 2, 2);
+	}
+	catch (...)
+	{
+		is_failed = true;
+	}
+
+	tester.check(is_failed);
+}
+
+// void r3r_validate_read_pixels_param(const R3rReadPixelsParam&, int, int)
+// Destination shorter than the image.
+void test_xjkwh00fug8d2tih()
+{
+	const auto param = bstone::R3rReadPixelsParam{
+		.pixel_format = bstone::sys::PixelFormat::r8g8b8,
+		.width = 4,
+		.height = 2,
+		.buffer = buffer};
+
+	auto is_failed = false;
+
+	try
+	{
+		bstone::r3r_validate_read_pixels_param(param, 4, 4);
+	}
+	catch (...)
+	{
+		is_failed = true;
+	}
+
+	tester.check(is_failed);
+}
+
+// ==========================================================================
+
+class Registrator
+{
+public:
+	Registrator()
+	{
+		register_validate_read_pixels_param();
+	}
+
+private:
+	void register_validate_read_pixels_param()
+	{
+		tester.register_test("R3r#togn86jyn8b42a2p", test_togn86jyn8b42a2p);
+		tester.register_test("R3r#2xzgqvr59z3omnta", test_2xzgqvr59z3omnta);
+		tester.register_test("R3r#63kn34qkp1o6p160", test_63kn34qkp1o6p160);
+		tester.register_test("R3r#0w65hpbd2w0u877t", test_0w65hpbd2w0u877t);
+		tester.register_test("R3r#6036ue7dgnn36t8z", test_6036ue7dgnn36t8z);
+		tester.register_test("R3r#xjkwh00fug8d2tih", test_xjkwh00fug8d2tih);
+	}
+};
+
+auto registrator = Registrator{};
+
+} // namespace


### PR DESCRIPTION
From a correctness review of wip.

- Resolve the MSAA framebuffer before reading pixels — the frame just submitted was still sitting in the MSAA framebuffer, so the screenshot picked up whatever the default framebuffer was left with
- Do not call glReadBuffer on the OpenGL ES 2.0 path — ES gained it only in 3.0, so the symbol may well be missing
- Size the screenshot buffer from the rendered image, not the video mode cvars — the window manager is free to hand out a drawable of some other size
- Always request a depth buffer for the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)