### PR TITLE
Make the Vulkan renderer correct on portability implementations

### DIFF
--- a/src/bstone/CMakeLists.txt
+++ b/src/bstone/CMakeLists.txt
@@ -485,6 +485,7 @@ set(BSTONE_BSTONE_RENDERER_3D_SOURCES
 	src/bstone_r3r_mgr.cpp
 	src/bstone_r3r_mgr.h
 	src/bstone_r3r_r2_texture.h
+	src/bstone_r3r_sample_count.h
 	src/bstone_r3r_sampler.h
 	src/bstone_r3r_shader.h
 	src/bstone_r3r_shader_stage.h

--- a/src/bstone/src/bstone_hw_texture_mgr.cpp
+++ b/src/bstone/src/bstone_hw_texture_mgr.cpp
@@ -595,6 +595,10 @@ void HwTextureMgrImpl::uninitialize()
 
 void HwTextureMgrImpl::recreate_indexed_resources()
 try {
+	// The textures replaced below are destroyed as soon as they are overwritten, so any
+	// frame still executing on the device must finish before that happens.
+	renderer_->wait_for_device();
+
 	// Sprites.
 	//
 	for (auto& sprite_item : sprite_map_)

--- a/src/bstone/src/bstone_r3r_sample_count.h
+++ b/src/bstone/src/bstone_r3r_sample_count.h
@@ -1,0 +1,55 @@
+/*
+BStone: Unofficial source port of Blake Stone: Aliens of Gold and Blake Stone: Planet Strike
+Copyright (c) 2013-2026 Boris I. Bendovsky (bibendovsky@hotmail.com) and Contributors
+SPDX-License-Identifier: MIT
+*/
+
+// 3D Renderer: Sample count
+//
+// A set of sample counts is a bit mask where the bit N stands for the sample count 1 << N.
+
+#ifndef BSTONE_R3R_SAMPLE_COUNT_INCLUDED
+#define BSTONE_R3R_SAMPLE_COUNT_INCLUDED
+
+#include "bstone_r3r_limits.h"
+
+namespace bstone {
+
+struct R3rSampleCount
+{
+	// The anti-aliasing limit is inclusive, hence the bit of the limit itself belongs to the mask.
+	static constexpr unsigned int supported_bitmask =
+		static_cast<unsigned int>(R3rLimits::max_aa) |
+		static_cast<unsigned int>(R3rLimits::max_aa - 1);
+
+	// Drops the sample counts the renderers don't expose.
+	static constexpr unsigned int clamp_bitmask(unsigned int bitmask)
+	{
+		return bitmask & supported_bitmask;
+	}
+
+	// Returns the greatest supported sample count of the mask not exceeding the degree,
+	// or one when there is none.
+	static constexpr int choose(unsigned int bitmask, int degree)
+	{
+		const unsigned int clamped_bitmask = clamp_bitmask(bitmask);
+		for (int sample_count = R3rLimits::max_aa; sample_count > 1; sample_count /= 2)
+		{
+			if (sample_count <= degree && (clamped_bitmask & static_cast<unsigned int>(sample_count)) != 0)
+			{
+				return sample_count;
+			}
+		}
+		return 1;
+	}
+
+	// Returns the greatest supported sample count of the mask, or one for an empty mask.
+	static constexpr int get_max(unsigned int bitmask)
+	{
+		return choose(bitmask, R3rLimits::max_aa);
+	}
+};
+
+} // namespace bstone
+
+#endif // BSTONE_R3R_SAMPLE_COUNT_INCLUDED

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -9,6 +9,7 @@ SPDX-License-Identifier: MIT
 #include "bstone_vk_r3r.h"
 #include "bstone_assert.h"
 #include "bstone_exception.h"
+#include "bstone_exception_utils.h"
 #include "bstone_scope_exit.h"
 #include "bstone_r3r_cmd_buffer.h"
 #include "bstone_r3r_limits.h"
@@ -262,7 +263,19 @@ private:
 
 VkR3rImpl::~VkR3rImpl()
 {
-	impl_wait_for_device();
+	// A lost device makes the wait fail, and a destructor may not throw. Report the
+	// failure and carry on with the teardown.
+	try
+	{
+		impl_wait_for_device();
+	}
+	catch (...)
+	{
+		for (const std::string& message : extract_exception_messages())
+		{
+			logger_.log_error(message.c_str());
+		}
+	}
 }
 
 VkR3rImpl::VkR3rImpl(sys::VideoMgr& video_mgr, sys::WindowMgr& window_mgr, const R3rInitParam& param)

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -315,7 +315,6 @@ try
 	initialize_transient_command_pool();
 	initialize_command_pool();
 	initialize_command_buffer();
-	initialize_swapchain_sync_objects();
 	initialize_sync_objects();
 	initialize_descriptor_pool();
 	initialize_pipeline_mgr();

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -1137,6 +1137,10 @@ void VkR3rImpl::initialize_enabled_global_extensions()
 	if (context_.has_khr_portability_enumeration)
 	{
 		context_.enabled_extensions.emplace_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+		// The device half of portability depends on this one, and the device is
+		// created from this instance, so it has to be asked for here too.
+		context_.enabled_extensions.emplace_back(
+			VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	}
 	std::span<const char* const> sys_required_extensions = video_mgr_.get_vulkan_mgr().get_required_extensions(*window_);
 	context_.enabled_extensions.reserve(
@@ -1545,8 +1549,10 @@ void VkR3rImpl::initialize_logical_device()
 		.flags = VkDeviceCreateFlags{},
 		.queueCreateInfoCount = 1,
 		.pQueueCreateInfos = &vk_device_queue_create_info,
-		.enabledLayerCount = static_cast<std::uint32_t>(context_.enabled_layers.size()),
-		.ppEnabledLayerNames = context_.enabled_layers.data(),
+		// Device-level layers were removed from the specification; a device now
+		// inherits the instance's, and passing any here is invalid.
+		.enabledLayerCount = 0,
+		.ppEnabledLayerNames = nullptr,
 		.enabledExtensionCount = static_cast<std::uint32_t>(context_.enabled_device_extensions.size()),
 		.ppEnabledExtensionNames = context_.enabled_device_extensions.data(),
 		.pEnabledFeatures = &vk_physical_device_features};

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -2218,10 +2218,11 @@ void VkR3rImpl::initialize_post_pipelines()
 
 void VkR3rImpl::initialize_post()
 {
-	if (!context_.has_swapchain())
-	{
-		return;
-	}
+	// Everything but the framebuffers and the pipelines is independent of the swapchain,
+	// and those two skip themselves while there is none. So create the rest right away:
+	// a renderer born without a swapchain still has to have a mapped uniform buffer and a
+	// descriptor set to write to, and the swapchain recreation expects the render pass and
+	// the shader modules to be around.
 	initialize_post_sampler();
 	initialize_post_uniform_buffer();
 	initialize_post_descriptor_set_layout();

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -48,6 +48,10 @@ namespace bstone {
 
 namespace {
 
+// Spelled out rather than taken from <vulkan/vulkan_beta.h>, which the build does
+// not include because it carries provisional extensions the port has no use for.
+constexpr const char* vk_khr_portability_subset_extension_name = "VK_KHR_portability_subset";
+
 class VkR3rImpl final : public R3r
 {
 public:
@@ -1099,6 +1103,10 @@ void VkR3rImpl::initialize_global_extensions()
 		{
 			context_.has_ext_debug_utils = true;
 		}
+		if (std::strcmp(extension.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0)
+		{
+			context_.has_khr_portability_enumeration = true;
+		}
 	}
 }
 
@@ -1123,6 +1131,13 @@ void VkR3rImpl::initialize_enabled_global_extensions()
 		context_.enabled_extensions.emplace_back(context_.vk_ext_debug_utils_extension_name);
 	}
 #endif // NDEBUG
+	// A driver that implements Vulkan on top of another API - MoltenVK, on macOS -
+	// is hidden from an application that does not ask to see it, and creating an
+	// instance fails outright where such a driver is the only one installed.
+	if (context_.has_khr_portability_enumeration)
+	{
+		context_.enabled_extensions.emplace_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+	}
 	std::span<const char* const> sys_required_extensions = video_mgr_.get_vulkan_mgr().get_required_extensions(*window_);
 	context_.enabled_extensions.reserve(
 		context_.enabled_extensions.size() + sys_required_extensions.size());
@@ -1176,6 +1191,10 @@ void VkR3rImpl::initialize_instance()
 		vk_instance_create_info.pNext = &vk_debug_utils_messenger_create_info;
 	}
 #endif // NDEBUG
+	if (context_.has_khr_portability_enumeration)
+	{
+		vk_instance_create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+	}
 	vk_instance_create_info.pApplicationInfo = &vk_application_info;
 	vk_instance_create_info.enabledLayerCount = static_cast<std::uint32_t>(context_.enabled_layers.size());
 	vk_instance_create_info.ppEnabledLayerNames = context_.enabled_layers.data();
@@ -1492,6 +1511,19 @@ void VkR3rImpl::initialize_enabled_device_extensions()
 	context_.enabled_device_extensions.clear();
 	context_.enabled_device_extensions.reserve(4);
 	context_.enabled_device_extensions.emplace_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+	// A device that implements only a subset of the specification must say so, and
+	// the specification requires an application that uses one to enable this.
+	const auto device_extensions = vk_r3r_extract_array(
+		context_.vkEnumerateDeviceExtensionProperties, context_.physical_device, nullptr);
+	for (const VkExtensionProperties& extension : device_extensions)
+	{
+		if (std::strcmp(extension.extensionName, vk_khr_portability_subset_extension_name) == 0)
+		{
+			context_.has_khr_portability_subset = true;
+			context_.enabled_device_extensions.emplace_back(vk_khr_portability_subset_extension_name);
+			break;
+		}
+	}
 }
 
 void VkR3rImpl::initialize_logical_device()

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -2527,16 +2527,20 @@ void VkR3rImpl::wait_for_previous_frame()
 
 void VkR3rImpl::swapchain_acquire_next_image()
 {
-	if (!context_.has_swapchain())
+	// A zero-sized surface has no swapchain to acquire an image from, and recreating it
+	// will not produce one until the surface has an area again. Bail out in that case,
+	// leaving the image index unset - the frame will be dropped.
+	constexpr int max_attempt_count = 4;
+	for (int i_attempt = 0; i_attempt < max_attempt_count; ++i_attempt)
 	{
-		recreate_swapchain();
 		if (!context_.has_swapchain())
 		{
-			return;
+			recreate_swapchain();
+			if (!context_.has_swapchain())
+			{
+				return;
+			}
 		}
-	}
-	for (;;)
-	{
 		const VkResult vk_result = context_.vkAcquireNextImageKHR(
 			/* device */      context_.device.get(),
 			/* swapchain */   context_.swapchain.get(),
@@ -2556,6 +2560,9 @@ void VkR3rImpl::swapchain_acquire_next_image()
 				return;
 		}
 	}
+	// A freshly recreated swapchain that is out of date again means the surface never
+	// settles. Report it instead of spinning here forever.
+	BSTONE_THROW_STATIC_SOURCE("Out of date swapchain.");
 }
 
 void VkR3rImpl::recreate_swapchain()

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -13,6 +13,7 @@ SPDX-License-Identifier: MIT
 #include "bstone_scope_exit.h"
 #include "bstone_r3r_cmd_buffer.h"
 #include "bstone_r3r_limits.h"
+#include "bstone_r3r_sample_count.h"
 #include "bstone_string_builder.h"
 #include "bstone_sys_logger.h"
 #include "bstone_vk_r3r_array_extractor.h"
@@ -852,15 +853,7 @@ void VkR3rImpl::ensure_vk_result(VkResult vk_result, const char* vk_name)
 
 int VkR3rImpl::get_max_sample_count() const
 {
-	for (int i_bit = 6; i_bit >= 0; --i_bit)
-	{
-		const unsigned int sample_count = 1U << i_bit;
-		if ((context_.sample_count_bitmask & sample_count) != 0)
-		{
-			return static_cast<int>(sample_count);
-		}
-	}
-	return 1;
+	return R3rSampleCount::get_max(context_.sample_count_bitmask);
 }
 
 int VkR3rImpl::choose_sample_count(R3rAaType aa_type, int aa_degree) const
@@ -873,17 +866,7 @@ int VkR3rImpl::choose_sample_count(R3rAaType aa_type, int aa_degree) const
 		default:
 			return 1;
 	}
-	const unsigned int max_sample_count = static_cast<unsigned int>(std::min(aa_degree, get_max_sample_count()));
-	for (int i_bit = 6; i_bit >= 0; --i_bit)
-	{
-		const unsigned int sample_count = 1U << i_bit;
-		if ((context_.sample_count_bitmask & sample_count) != 0 &&
-			sample_count <= max_sample_count)
-		{
-			return static_cast<int>(sample_count);
-		}
-	}
-	return 1;
+	return R3rSampleCount::choose(context_.sample_count_bitmask, aa_degree);
 }
 
 VkPresentModeKHR VkR3rImpl::choose_present_mode(bool enable_vsync) const
@@ -2478,7 +2461,7 @@ void VkR3rImpl::initialize_sample_count(const R3rInitParam& r3r_init_param)
 	// Ensure at least one sample count.
 	context_.sample_count_bitmask |= VK_SAMPLE_COUNT_1_BIT;
 	// Apply the limit.
-	context_.sample_count_bitmask &= R3rLimits::max_aa - 1;
+	context_.sample_count_bitmask = R3rSampleCount::clamp_bitmask(context_.sample_count_bitmask);
 	BSTONE_ASSERT(context_.sample_count_bitmask != 0);
 	context_.sample_count = choose_sample_count(r3r_init_param.aa_type, r3r_init_param.aa_value);
 }

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -360,6 +360,7 @@ try
 	context_.vk_offscreen_height = static_cast<std::uint32_t>(new_size.height);
 	if (context_.vk_offscreen_width != old_width || context_.vk_offscreen_height != old_height)
 	{
+		impl_wait_for_device();
 		terminate_offscreen_framebuffer();
 		initialize_offscreen_framebuffer();
 		context_.draw_state_update_scissor();

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -50,7 +50,6 @@ namespace {
 
 // Spelled out rather than taken from <vulkan/vulkan_beta.h>, which the build does
 // not include because it carries provisional extensions the port has no use for.
-constexpr const char* vk_khr_portability_subset_extension_name = "VK_KHR_portability_subset";
 
 class VkR3rImpl final : public R3r
 {
@@ -1548,10 +1547,10 @@ void VkR3rImpl::initialize_enabled_device_extensions()
 		context_.vkEnumerateDeviceExtensionProperties, context_.physical_device, nullptr);
 	for (const VkExtensionProperties& extension : device_extensions)
 	{
-		if (std::strcmp(extension.extensionName, vk_khr_portability_subset_extension_name) == 0)
+		if (std::strcmp(extension.extensionName, VkR3rContext::vk_khr_portability_subset_extension_name) == 0)
 		{
 			context_.has_khr_portability_subset = true;
-			context_.enabled_device_extensions.emplace_back(vk_khr_portability_subset_extension_name);
+			context_.enabled_device_extensions.emplace_back(VkR3rContext::vk_khr_portability_subset_extension_name);
 			break;
 		}
 	}

--- a/src/bstone/src/bstone_vk_r3r.cpp
+++ b/src/bstone/src/bstone_vk_r3r.cpp
@@ -118,6 +118,8 @@ private:
 	R3rDeviceInfo device_info_{};
 	sys::WindowUPtr window_{};
 	VkR3rContext context_{};
+	// Set once the logical device exists, so the resolver can prefer it.
+	VkDevice symbol_device_{};
 	VkR3rPipelineMgrUPtr pipeline_mgr_{};
 	FrameState frame_state_{};
 
@@ -128,6 +130,23 @@ private:
 	void resolve_symbol(VkInstance instance, const char* name, T& symbol)
 	{
 		BSTONE_ASSERT(context_.vkGetInstanceProcAddr != nullptr);
+		// Once there is a device, ask it first. A device-level command obtained this
+		// way skips the loader's dispatch and so must be paired with the handles that
+		// same path produces; mixing the two hands a command a handle it cannot
+		// dispatch on. Anything that is not device-level answers null here and falls
+		// through to the instance, which is how the two lists stay separated without
+		// naming every command twice.
+		if (symbol_device_ != VK_NULL_HANDLE && context_.vkGetDeviceProcAddr != nullptr)
+		{
+			PFN_vkVoidFunction const device_symbol_void = context_.vkGetDeviceProcAddr(
+				/* device */ symbol_device_,
+				/* pName */  name);
+			if (device_symbol_void != nullptr)
+			{
+				symbol = reinterpret_cast<T>(device_symbol_void);
+				return;
+			}
+		}
 		PFN_vkVoidFunction const symbol_void = context_.vkGetInstanceProcAddr(
 			/* instance */ instance,
 			/* pName */    name);
@@ -177,6 +196,7 @@ private:
 	void initialize_enabled_global_extensions();
 	void initialize_instance();
 	void initialize_instance_symbols();
+	void initialize_device_symbols();
 	void initialize_debug_utils_messenger();
 	void initialize_surface();
 	void update_surface_capabilities();
@@ -1216,6 +1236,26 @@ void VkR3rImpl::initialize_instance()
 
 void VkR3rImpl::initialize_instance_symbols()
 {
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkCreateDevice));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkDestroySurfaceKHR));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkEnumerateDeviceExtensionProperties));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkEnumeratePhysicalDevices));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetDeviceProcAddr));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceFeatures));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceMemoryProperties));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceFormatProperties));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceProperties));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceQueueFamilyProperties));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceSurfaceCapabilitiesKHR));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceSurfaceFormatsKHR));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceSurfacePresentModesKHR));
+	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceSurfaceSupportKHR));
+}
+
+void VkR3rImpl::initialize_device_symbols()
+{
+	// Resolved through the device, so these dispatch on the handles the device
+	// itself produces rather than going back through the instance.
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkAcquireNextImageKHR));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkAllocateCommandBuffers));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkAllocateDescriptorSets));
@@ -1244,7 +1284,6 @@ void VkR3rImpl::initialize_instance_symbols()
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkCreateCommandPool));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkCreateDescriptorPool));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkCreateDescriptorSetLayout));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkCreateDevice));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkCreateFence));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkCreateFramebuffer));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkCreateGraphicsPipelines));
@@ -1271,27 +1310,15 @@ void VkR3rImpl::initialize_instance_symbols()
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkDestroySampler));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkDestroySemaphore));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkDestroyShaderModule));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkDestroySurfaceKHR));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkDestroySwapchainKHR));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkDeviceWaitIdle));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkEndCommandBuffer));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkEnumerateDeviceExtensionProperties));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkEnumeratePhysicalDevices));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkFreeCommandBuffers));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkFreeDescriptorSets));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkFreeMemory));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetBufferMemoryRequirements));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetDeviceQueue));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetImageMemoryRequirements));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceFeatures));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceMemoryProperties));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceFormatProperties));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceProperties));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceQueueFamilyProperties));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceSurfaceCapabilitiesKHR));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceSurfaceFormatsKHR));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceSurfacePresentModesKHR));
-	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetPhysicalDeviceSurfaceSupportKHR));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkGetSwapchainImagesKHR));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkMapMemory));
 	resolve_symbol(context_.instance.get(), BSTONE_STRCTX(vkQueuePresentKHR));
@@ -1564,6 +1591,12 @@ void VkR3rImpl::initialize_logical_device()
 		/* pDevice */        &vk_device);
 	ensure_vk_result(vk_result, "vkCreateDevice");
 	context_.device = VkR3rDeviceResource{vk_device, VkR3rDeviceDeleter{context_}};
+	// Take the device-level commands from the device now that there is one. This has
+	// to happen before the queue is fetched: a command obtained from the device
+	// dispatches on the handles that path produces, so the queue and the calls that
+	// later submit to it must both come from it.
+	symbol_device_ = vk_device;
+	initialize_device_symbols();
 	context_.vkGetDeviceQueue(
 		/* device */           vk_device,
 		/* queueFamilyIndex */ context_.queue_family_index,

--- a/src/bstone/src/bstone_vk_r3r_context.cpp
+++ b/src/bstone/src/bstone_vk_r3r_context.cpp
@@ -17,6 +17,7 @@ namespace bstone {
 
 const char* const VkR3rContext::vk_layer_khronos_validation_extension_name = "VK_LAYER_KHRONOS_validation";
 const char* const VkR3rContext::vk_ext_debug_utils_extension_name = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;
+const char* const VkR3rContext::vk_khr_portability_subset_extension_name = "VK_KHR_portability_subset";
 
 // --------------------------------------
 

--- a/src/bstone/src/bstone_vk_r3r_context.h
+++ b/src/bstone/src/bstone_vk_r3r_context.h
@@ -26,6 +26,7 @@ class VkR3rContext
 public:
 	static const char* const vk_layer_khronos_validation_extension_name;
 	static const char* const vk_ext_debug_utils_extension_name;
+	static const char* const vk_khr_portability_subset_extension_name;
 	static constexpr std::uint32_t total_attachments = 2;
 	static constexpr std::uint32_t color_attachment_index = 0;
 	static constexpr std::uint32_t depth_attachment_index = 1;

--- a/src/bstone/src/bstone_vk_r3r_context.h
+++ b/src/bstone/src/bstone_vk_r3r_context.h
@@ -75,6 +75,7 @@ public:
 	};
 
 	PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr{};
+	PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr{};
 	PFN_vkCreateInstance vkCreateInstance{};
 	PFN_vkEnumerateInstanceExtensionProperties vkEnumerateInstanceExtensionProperties{};
 	PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties{};

--- a/src/bstone/src/bstone_vk_r3r_context.h
+++ b/src/bstone/src/bstone_vk_r3r_context.h
@@ -171,6 +171,8 @@ public:
 
 	bool has_vk_layer_khronos_validation{};
 	bool has_ext_debug_utils{};
+	bool has_khr_portability_enumeration{};
+	bool has_khr_portability_subset{};
 	bool has_vk_present_mode_immediate_khr{};
 	bool has_vk_present_mode_fifo_khr{};
 

--- a/src/bstone/src/bstone_vk_r3r_r2_texture.cpp
+++ b/src/bstone/src/bstone_vk_r3r_r2_texture.cpp
@@ -38,9 +38,10 @@ private:
 	using ImageLayouts = std::array<VkImageLayout, R3rLimits::max_mip_levels>;
 
 	VkR3rContext& context_;
+	// Destroyed in reverse declaration order: the view first, then the image, then its memory.
 	VkR3rDeviceMemoryResource image_device_memory_resource_{};
-	VkR3rImageViewResource image_view_resource_{};
 	VkR3rImageResource image_resource_{};
+	VkR3rImageViewResource image_view_resource_{};
 	VkR3rDeviceMemoryResource staging_buffer_device_memory_resource_{};
 	VkR3rBufferResource staging_buffer_resource_{};
 	void* staging_buffer_mapped_memory_{};

--- a/src/bstone/src/bstone_vk_r3r_vertex_input.cpp
+++ b/src/bstone/src/bstone_vk_r3r_vertex_input.cpp
@@ -148,11 +148,14 @@ try
 			.inputRate = VK_VERTEX_INPUT_RATE_VERTEX});
 	if (vk_generic_offset > 0)
 	{
+		// Every vertex must read the same default values. A zero stride would do, but
+		// VK_KHR_portability_subset (Metal) forbids attributes that extend past the
+		// stride; per-instance rate is equivalent since all draws are single-instance.
 		vk_vertex_input_binding_descriptions_.emplace_back(
 			VkVertexInputBindingDescription{
 				.binding   = 1,
-				.stride    = 0,
-				.inputRate = VK_VERTEX_INPUT_RATE_VERTEX});
+				.stride    = vk_generic_offset,
+				.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE});
 		initialize_generic_buffer(default_values);
 	}
 	vk_pipeline_vertex_input_state_create_info_ = VkPipelineVertexInputStateCreateInfo{

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -84,6 +84,8 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_win32_advapi32_symbols.cpp
 		../../../bstone/src/bstone_win32_advapi32_symbols.h
 		../../../bstone/src/bstone_four_cc.h
+		../../../bstone/src/bstone_r3r_limits.h
+		../../../bstone/src/bstone_r3r_sample_count.h
 		../../../bstone/src/bstone_win32_os_version.cpp
 		../../../bstone/src/bstone_win32_os_version.h
 		../../../bstone/src/bstone_win32_utility.cpp
@@ -159,6 +161,7 @@ target_sources(bstone_tests
 		src/bstone_tests_opl_sfx_decoder.cpp
 		src/bstone_tests_opl_music_decoder.cpp
 		src/bstone_tests_r3r.cpp
+		src/bstone_tests_r3r_sample_count.cpp
 	PRIVATE
 		src/bstone_tester.cpp
 		src/bstone_tester.h

--- a/src/tests/src/tests/src/bstone_tests_r3r_sample_count.cpp
+++ b/src/tests/src/tests/src/bstone_tests_r3r_sample_count.cpp
@@ -1,0 +1,173 @@
+#include "bstone_r3r_sample_count.h"
+#include "bstone_tester.h"
+
+namespace {
+
+auto tester = bstone::Tester{};
+
+// ==========================================================================
+
+// unsigned int clamp_bitmask(unsigned int)
+// Keeps every sample count up to the limit.
+void test_z2j4qk8fxr0m5vwd()
+{
+	constexpr auto bitmask = bstone::R3rSampleCount::clamp_bitmask(0x3FU);
+	const auto is_valid_value = bitmask == 0x3FU;
+	tester.check(is_valid_value);
+}
+
+// unsigned int clamp_bitmask(unsigned int)
+// Keeps the limit itself.
+void test_p7c1nubs9lta3ke6()
+{
+	constexpr auto bitmask = bstone::R3rSampleCount::clamp_bitmask(
+		static_cast<unsigned int>(bstone::R3rLimits::max_aa));
+	const auto is_valid_value = bitmask == static_cast<unsigned int>(bstone::R3rLimits::max_aa);
+	tester.check(is_valid_value);
+}
+
+// unsigned int clamp_bitmask(unsigned int)
+// Drops the sample counts beyond the limit.
+void test_h5v8drqy1o6wgn3t()
+{
+	constexpr auto bitmask = bstone::R3rSampleCount::clamp_bitmask(0xFFU);
+	const auto is_valid_value = bitmask == 0x3FU;
+	tester.check(is_valid_value);
+}
+
+// unsigned int clamp_bitmask(unsigned int)
+// An empty mask stays empty.
+void test_a0mzl6ei4rf2sxq9()
+{
+	constexpr auto bitmask = bstone::R3rSampleCount::clamp_bitmask(0U);
+	const auto is_valid_value = bitmask == 0U;
+	tester.check(is_valid_value);
+}
+
+// ==========================================================================
+
+// int choose(unsigned int, int)
+// The degree is an upper bound.
+void test_k3wq7t5ybn0icfa8()
+{
+	constexpr auto sample_count = bstone::R3rSampleCount::choose(0x3FU, 8);
+	const auto is_valid_value = sample_count == 8;
+	tester.check(is_valid_value);
+}
+
+// int choose(unsigned int, int)
+// The greatest sample count of the mask not exceeding the degree.
+void test_q9dxu2ml7gvopr41()
+{
+	constexpr auto sample_count = bstone::R3rSampleCount::choose(0x05U, 8);
+	const auto is_valid_value = sample_count == 4;
+	tester.check(is_valid_value);
+}
+
+// int choose(unsigned int, int)
+// The limit itself is choosable.
+void test_t6bnf3zwc8shje2p()
+{
+	constexpr auto sample_count = bstone::R3rSampleCount::choose(0x3FU, bstone::R3rLimits::max_aa);
+	const auto is_valid_value = sample_count == bstone::R3rLimits::max_aa;
+	tester.check(is_valid_value);
+}
+
+// int choose(unsigned int, int)
+// A degree beyond the limit doesn't exceed it.
+void test_x1grso4kdv9ylb7m()
+{
+	constexpr auto sample_count = bstone::R3rSampleCount::choose(0xFFU, 1024);
+	const auto is_valid_value = sample_count == bstone::R3rLimits::max_aa;
+	tester.check(is_valid_value);
+}
+
+// int choose(unsigned int, int)
+// No anti-aliasing when nothing fits the degree.
+void test_v4ehp0nq6yui8w3c()
+{
+	constexpr auto sample_count = bstone::R3rSampleCount::choose(0x20U, 16);
+	const auto is_valid_value = sample_count == 1;
+	tester.check(is_valid_value);
+}
+
+// int choose(unsigned int, int)
+// No anti-aliasing for an empty mask.
+void test_m2sfk9rjxo5taz1u()
+{
+	constexpr auto sample_count = bstone::R3rSampleCount::choose(0U, bstone::R3rLimits::max_aa);
+	const auto is_valid_value = sample_count == 1;
+	tester.check(is_valid_value);
+}
+
+// ==========================================================================
+
+// int get_max(unsigned int)
+// The greatest sample count of the mask.
+void test_r8ylc3wgn1vke67d()
+{
+	constexpr auto sample_count = bstone::R3rSampleCount::get_max(0x15U);
+	const auto is_valid_value = sample_count == 16;
+	tester.check(is_valid_value);
+}
+
+// int get_max(unsigned int)
+// The limit is reachable.
+void test_j5ot2xbma9qz4hpw()
+{
+	constexpr auto sample_count = bstone::R3rSampleCount::get_max(0x7FU);
+	const auto is_valid_value = sample_count == bstone::R3rLimits::max_aa;
+	tester.check(is_valid_value);
+}
+
+// int get_max(unsigned int)
+// No anti-aliasing for an empty mask.
+void test_w0izq6dtn3ub8fys()
+{
+	constexpr auto sample_count = bstone::R3rSampleCount::get_max(0U);
+	const auto is_valid_value = sample_count == 1;
+	tester.check(is_valid_value);
+}
+
+// ==========================================================================
+
+class Registrator
+{
+public:
+	Registrator()
+	{
+		register_clamp_bitmask();
+		register_choose();
+		register_get_max();
+	}
+
+private:
+	void register_clamp_bitmask()
+	{
+		tester.register_test("R3rSampleCount#z2j4qk8fxr0m5vwd", test_z2j4qk8fxr0m5vwd);
+		tester.register_test("R3rSampleCount#p7c1nubs9lta3ke6", test_p7c1nubs9lta3ke6);
+		tester.register_test("R3rSampleCount#h5v8drqy1o6wgn3t", test_h5v8drqy1o6wgn3t);
+		tester.register_test("R3rSampleCount#a0mzl6ei4rf2sxq9", test_a0mzl6ei4rf2sxq9);
+	}
+
+	void register_choose()
+	{
+		tester.register_test("R3rSampleCount#k3wq7t5ybn0icfa8", test_k3wq7t5ybn0icfa8);
+		tester.register_test("R3rSampleCount#q9dxu2ml7gvopr41", test_q9dxu2ml7gvopr41);
+		tester.register_test("R3rSampleCount#t6bnf3zwc8shje2p", test_t6bnf3zwc8shje2p);
+		tester.register_test("R3rSampleCount#x1grso4kdv9ylb7m", test_x1grso4kdv9ylb7m);
+		tester.register_test("R3rSampleCount#v4ehp0nq6yui8w3c", test_v4ehp0nq6yui8w3c);
+		tester.register_test("R3rSampleCount#m2sfk9rjxo5taz1u", test_m2sfk9rjxo5taz1u);
+	}
+
+	void register_get_max()
+	{
+		tester.register_test("R3rSampleCount#r8ylc3wgn1vke67d", test_r8ylc3wgn1vke67d);
+		tester.register_test("R3rSampleCount#j5ot2xbma9qz4hpw", test_j5ot2xbma9qz4hpw);
+		tester.register_test("R3rSampleCount#w0izq6dtn3ub8fys", test_w0izq6dtn3ub8fys);
+	}
+};
+
+auto registrator = Registrator{};
+
+} // namespace


### PR DESCRIPTION
Found by running wip under MoltenVK with validation layers on macOS; every fix maps to an observed crash or validation error.

- Resolve device-level commands through the device — everything was resolved from the instance, so submitting on the queue dereferenced the loader magic of a raw ICD handle and crashed
- Ask to see drivers that implement Vulkan on another API, and enable VK_KHR_portability_subset — without the enumeration flag vkCreateInstance fails with VK_ERROR_INCOMPATIBLE_DRIVER on macOS
- Correct two mistakes in device creation — device-level layers are gone from the specification
- Destroy an image view before the image it views, and wait for the device before replacing textures — recreating textures while frames were in flight faulted the GPU and lost the device
- Keep default-attribute reads inside the binding stride — portability implementations forbid an attribute extending past its binding's stride
- Create the per-image semaphores once; report a failed device wait on teardown instead of aborting; create the post-processing resources without a swapchain; do not acquire an image from a destroyed swapchain; wait for the device before dropping the offscreen framebuffer; keep the highest anti-aliasing degree selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)