### PR TITLE
Deliver quit events and survive SDL3's asynchronous fullscreen

### DIFF
--- a/src/bstone/src/3d_main.cpp
+++ b/src/bstone/src/3d_main.cpp
@@ -9993,9 +9993,16 @@ int main(
 
 		void log(bstone::sys::LogLevel level, const char* message) override
 		{
-			BSTONE_ASSERT(level == bstone::sys::LogLevel::information);
-			static_cast<void>(level);
-			logger_.log_information(message != nullptr ? message : "");
+			// The graphics and audio back-ends report real warnings and failures
+			// through here - a lost device, for one - so the level has to be carried
+			// across rather than assumed to be informational.
+			const char* const text = message != nullptr ? message : "";
+			switch (level)
+			{
+				case bstone::sys::LogLevel::warning: logger_.log_warning(text); break;
+				case bstone::sys::LogLevel::error: logger_.log_error(text); break;
+				default: logger_.log_information(text); break;
+			}
 		}
 
 	private:

--- a/src/bstone/src/bstone_hw_video.cpp
+++ b/src/bstone/src/bstone_hw_video.cpp
@@ -1500,7 +1500,22 @@ try {
 
 HwVideo::~HwVideo()
 {
-	uninitialize_video();
+	// Tearing down waits for the device, and that wait fails once the device has
+	// been lost. A destructor may not throw, so report the failure and let the
+	// rest of the shut-down run. Reporting must not throw either, or the
+	// destructor ends the process just the same.
+	try
+	{
+		uninitialize_video();
+	}
+	catch (...)
+	{
+		try
+		{
+			log_error("Failed to uninitialize the video system.");
+		}
+		catch (...) {}
+	}
 }
 
 bool HwVideo::is_hardware() const

--- a/src/bstone/src/bstone_hw_video.cpp
+++ b/src/bstone/src/bstone_hw_video.cpp
@@ -68,6 +68,7 @@ public:
 
 	void apply_widescreen() override;
 	void apply_window_mode() override;
+	void handle_window_size_changed(int width, int height) override;
 	void apply_filler_color_index() override;
 
 	void apply_brightness() override;
@@ -970,6 +971,7 @@ private:
 	void initialize_palette();
 
 	void calculate_dimensions(int window_width, int window_height);
+	void apply_window_size(sys::WindowSize window_size);
 
 	void build_2d_model_matrix();
 	void build_2d_view_matrix();
@@ -1796,8 +1798,12 @@ try {
 		},
 	};
 	sys::Window& window = renderer_->get_window();
-	R3rUtils::set_window_mode(window, param);
-	const sys::WindowSize window_size = window.get_size_in_pixels();
+	const sys::WindowSize window_size = R3rUtils::set_window_mode(window, param);
+	apply_window_size(window_size);
+} BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
+
+void HwVideo::apply_window_size(sys::WindowSize window_size)
+try {
 	calculate_dimensions(window_size.width, window_size.height);
 	vid_initialize_vanilla_raycaster();
 	renderer_->handle_resize(sys::WindowSize{vid_layout_.window_width, vid_layout_.window_height});
@@ -1815,6 +1821,15 @@ try {
 		//
 		build_matrices();
 	}
+} BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
+
+void HwVideo::handle_window_size_changed(int width, int height)
+try {
+	if (width == vid_layout_.window_width && height == vid_layout_.window_height)
+	{
+		return;
+	}
+	apply_window_size(sys::WindowSize{.width = width, .height = height});
 } BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
 
 void HwVideo::apply_filler_color_index()

--- a/src/bstone/src/bstone_r3r_utils.cpp
+++ b/src/bstone/src/bstone_r3r_utils.cpp
@@ -122,12 +122,13 @@ try {
 	return window_mgr.make_window(window_param);
 } BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
 
-void R3rUtils::set_window_mode(sys::Window& window, const R3rUtilsSetWindowModeParam& param)
+sys::WindowSize R3rUtils::set_window_mode(sys::Window& window, const R3rUtilsSetWindowModeParam& param)
 try {
 	sys::DisplayMode display_mode = param.display_mode;
 	display_mode.width = std::max(display_mode.width, window_min_width);
 	display_mode.height = std::max(display_mode.height, window_min_height);
 	display_mode.refresh_rate = std::max(display_mode.refresh_rate, 0.0F);
+	sys::WindowSize window_size{};
 	switch (param.fullscreen_mode)
 	{
 		case sys::WindowFullscreenType::none:
@@ -142,14 +143,30 @@ try {
 			{
 				window.center();
 			}
+			window_size = sys::WindowSize{.width = display_mode.width, .height = display_mode.height};
 			break;
 		case sys::WindowFullscreenType::exclusive:
-			window.set_exclusive_fullscreen_mode(display_mode);
+		{
+			// Size from the chosen mode, not the window: the fullscreen
+			// transition is asynchronous, and a still-hidden startup window
+			// keeps reporting its pre-fullscreen size until shown.
+			const sys::DisplayMode chosen_mode = window.set_exclusive_fullscreen_mode(display_mode);
+			window_size = sys::WindowSize{.width = chosen_mode.width, .height = chosen_mode.height};
 			break;
+		}
 		case sys::WindowFullscreenType::fake:
 			window.set_fake_fullscreen_mode();
 			break;
 	}
+	window.sync();
+	if (window_size.width <= 0 || window_size.height <= 0)
+	{
+		// Fake fullscreen: no requested size to fall back on. After sync()
+		// a visible window reports the truth; a hidden one corrects itself
+		// via the pixel-size-changed event once shown.
+		window_size = window.get_size_in_pixels();
+	}
+	return window_size;
 } BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
 
 void R3rUtils::validate_initialize_param(const R3rInitParam& param)

--- a/src/bstone/src/bstone_r3r_utils.h
+++ b/src/bstone/src/bstone_r3r_utils.h
@@ -71,7 +71,11 @@ public:
 		const R3rUtilsCreateWindowParam& param,
 		sys::WindowMgr& window_mgr);
 
-	static void set_window_mode(sys::Window& window, const R3rUtilsSetWindowModeParam& param);
+	// Applies the mode and returns the window's resulting size in pixels.
+	// SDL3 applies mode changes asynchronously (and defers them entirely for
+	// hidden windows), so the returned size is derived from the requested or
+	// chosen mode rather than a live query wherever possible.
+	static sys::WindowSize set_window_mode(sys::Window& window, const R3rUtilsSetWindowModeParam& param);
 
 	static void validate_initialize_param(const R3rInitParam& param);
 

--- a/src/bstone/src/bstone_sw_video.cpp
+++ b/src/bstone/src/bstone_sw_video.cpp
@@ -53,6 +53,7 @@ public:
 
 	void apply_widescreen() override;
 	void apply_window_mode() override;
+	void handle_window_size_changed(int width, int height) override;
 	void apply_filler_color_index() override;
 
 	void fade_out(int start, int end, int red, int green, int blue, int steps) override;
@@ -128,6 +129,7 @@ private:
 	void initialize_textures();
 	void initialize_palette();
 	void calculate_dimensions(int window_width, int window_height);
+	void apply_window_size(sys::WindowSize window_size);
 	void uninitialize_vga_buffer();
 	static std::uint32_t convert_vga_color_to_u32(const VgaColor& vga_color);
 	void update_should_adjust_color();
@@ -481,14 +483,27 @@ try {
 		},
 	};
 	sys::Window& window = *window_;
-	R3rUtils::set_window_mode(window, param);
-	const sys::WindowSize window_size = window.get_size_in_pixels();
+	const sys::WindowSize window_size = R3rUtils::set_window_mode(window, param);
+	apply_window_size(window_size);
+} BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
+
+void SwVideo::apply_window_size(sys::WindowSize window_size)
+try {
 	calculate_dimensions(window_size.width, window_size.height);
 	vid_initialize_vanilla_raycaster();
 	vid_initialize_common();
 	uninitialize_textures();
 	initialize_textures();
 	initialize_vga_buffer();
+} BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
+
+void SwVideo::handle_window_size_changed(int width, int height)
+try {
+	if (width == vid_layout_.window_width && height == vid_layout_.window_height)
+	{
+		return;
+	}
+	apply_window_size(sys::WindowSize{.width = width, .height = height});
 } BSTONE_END_FUNC_CATCH_ALL_THROW_NESTED
 
 void SwVideo::apply_filler_color_index()

--- a/src/bstone/src/bstone_sys_event.h
+++ b/src/bstone/src/bstone_sys_event.h
@@ -72,12 +72,16 @@ enum class WindowEventType
 	none,
 	keyboard_focus_gained,
 	keyboard_focus_lost,
+	pixel_size_changed,
 };
 
 struct WindowEvent : CommonEvent
 {
 	WindowEventType event_type;
 	unsigned int id;
+	// New size in pixels; set only for `pixel_size_changed`.
+	int width;
+	int height;
 };
 
 union Event

--- a/src/bstone/src/bstone_sys_event_mgr_sdl.cpp
+++ b/src/bstone/src/bstone_sys_event_mgr_sdl.cpp
@@ -471,6 +471,12 @@ bool EventMgrSdl::handle_event(const SDL_Event& sdl_e, Event& e)
 		case SDL_EVENT_WINDOW_FOCUS_GAINED:
 		case SDL_EVENT_WINDOW_FOCUS_LOST:
 			return handle_event(sdl_e.window, e.window);
+		case SDL_EVENT_QUIT:
+			// Closing the last window, quitting from the dock or the application
+			// menu, and a termination request from the system all arrive as this.
+			e.common.type = EventType::quit;
+			e.common.timestamp = static_cast<unsigned long long>(sdl_e.quit.timestamp);
+			return true;
 		default:
 			return false;
 	}

--- a/src/bstone/src/bstone_sys_event_mgr_sdl.cpp
+++ b/src/bstone/src/bstone_sys_event_mgr_sdl.cpp
@@ -442,6 +442,13 @@ bool EventMgrSdl::handle_event(const SDL_WindowEvent& sdl_e, WindowEvent& e)
 		case SDL_EVENT_WINDOW_FOCUS_LOST:
 			e.event_type = WindowEventType::keyboard_focus_lost;
 			break;
+		case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+			// SDL3 mode changes land asynchronously (deferred past show() for
+			// windows created hidden), so the real size arrives here.
+			e.event_type = WindowEventType::pixel_size_changed;
+			e.width = static_cast<int>(sdl_e.data1);
+			e.height = static_cast<int>(sdl_e.data2);
+			break;
 		default:
 			is_handled = false;
 			break;

--- a/src/bstone/src/bstone_sys_window.h
+++ b/src/bstone/src/bstone_sys_window.h
@@ -151,8 +151,14 @@ public:
 	virtual void set_rounded_corner_type(WindowRoundedCornerType value) = 0;
 	virtual WindowFullscreenType get_fullscreen_mode() = 0;
 	virtual void set_windowed_mode(WindowSize window_size) = 0;
-	virtual void set_exclusive_fullscreen_mode(DisplayMode display_mode) = 0;
+	// Returns the display mode that was actually chosen for the window; the
+	// transition itself may still be pending (SDL3 applies it asynchronously,
+	// and not before a hidden window is shown).
+	virtual DisplayMode set_exclusive_fullscreen_mode(DisplayMode display_mode) = 0;
 	virtual void set_fake_fullscreen_mode() = 0;
+	// Blocks until pending size/mode changes are applied where possible;
+	// a hidden window keeps its changes deferred, so this returns at once.
+	virtual void sync() = 0;
 	virtual GlContextUPtr gl_make_context() = 0;
 	virtual WindowSize get_size_in_pixels() = 0;
 	virtual void gl_swap_buffers() = 0;

--- a/src/bstone/src/bstone_sys_window_sdl.cpp
+++ b/src/bstone/src/bstone_sys_window_sdl.cpp
@@ -43,8 +43,9 @@ public:
 	void set_rounded_corner_type(WindowRoundedCornerType value) override;
 	WindowFullscreenType get_fullscreen_mode() override;
 	void set_windowed_mode(WindowSize window_size) override;
-	void set_exclusive_fullscreen_mode(DisplayMode display_mode) override;
+	DisplayMode set_exclusive_fullscreen_mode(DisplayMode display_mode) override;
 	void set_fake_fullscreen_mode() override;
+	void sync() override;
 	GlContextUPtr gl_make_context() override;
 	WindowSize get_size_in_pixels() override;
 	void gl_swap_buffers() override;
@@ -257,7 +258,7 @@ void WindowSdl::set_windowed_mode(WindowSize window_size)
 	}
 }
 
-void WindowSdl::set_exclusive_fullscreen_mode(DisplayMode display_mode)
+DisplayMode WindowSdl::set_exclusive_fullscreen_mode(DisplayMode display_mode)
 {
 	const SDL_DisplayID sdl_display_id = SDL_GetDisplayForWindow(sdl_window_);
 	if (sdl_display_id == 0)
@@ -283,6 +284,11 @@ void WindowSdl::set_exclusive_fullscreen_mode(DisplayMode display_mode)
 	{
 		sdl::fail("SDL_SetWindowFullscreen");
 	}
+	return DisplayMode{
+		.width = sdl_display_mode.w,
+		.height = sdl_display_mode.h,
+		.refresh_rate = sdl_display_mode.refresh_rate,
+	};
 }
 
 void WindowSdl::set_fake_fullscreen_mode()
@@ -295,6 +301,18 @@ void WindowSdl::set_fake_fullscreen_mode()
 	{
 		sdl::fail("SDL_SetWindowFullscreen");
 	}
+}
+
+void WindowSdl::sync()
+{
+	// A hidden window keeps size/mode requests deferred until it is shown;
+	// waiting on it would only burn SDL_SyncWindow's timeout.
+	if ((SDL_GetWindowFlags(sdl_window_) & SDL_WINDOW_HIDDEN) != 0)
+	{
+		return;
+	}
+	// Best effort: false only means some request is still pending.
+	SDL_SyncWindow(sdl_window_);
 }
 
 GlContextUPtr WindowSdl::gl_make_context()

--- a/src/bstone/src/bstone_video.h
+++ b/src/bstone/src/bstone_video.h
@@ -77,6 +77,11 @@ public:
 
 	virtual void apply_window_mode() = 0;
 
+	// Re-derives the layout from the window's actual pixel size. SDL3 applies
+	// mode changes asynchronously, so this can arrive well after
+	// apply_window_mode - notably right after the startup window is shown.
+	virtual void handle_window_size_changed(int width, int height) = 0;
+
 	virtual void apply_filler_color_index() = 0;
 
 	virtual void apply_brightness() = 0;

--- a/src/bstone/src/id_in.cpp
+++ b/src/bstone/src/id_in.cpp
@@ -777,6 +777,10 @@ void in_handle_window(const bstone::sys::WindowEvent& e)
 			sd_mute(true);
 			break;
 
+		case bstone::sys::WindowEventType::pixel_size_changed:
+			vid_handle_window_size_changed(e.width, e.height);
+			break;
+
 		default: break;
 	}
 

--- a/src/bstone/src/id_vl.cpp
+++ b/src/bstone/src/id_vl.cpp
@@ -1266,6 +1266,15 @@ auto g_video = bstone::VideoUPtr{};
 } // namespace
 
 
+void vid_handle_window_size_changed(int width, int height)
+{
+	if (g_video == nullptr)
+	{
+		return;
+	}
+	g_video->handle_window_size_changed(width, height);
+}
+
 std::string vid_get_window_title_for_renderer(std::string_view renderer_name)
 try {
 	const auto game_name_and_game_version_string = vid_get_game_name_and_game_version_string();

--- a/src/bstone/src/id_vl.h
+++ b/src/bstone/src/id_vl.h
@@ -293,6 +293,10 @@ void VL_ScreenToMem(
 
 void vid_initialize_cvars(bstone::CVarMgr& cvar_mgr);
 
+// Forwards the window's actual pixel size to the active video system once
+// SDL3's asynchronous mode change has really been applied.
+void vid_handle_window_size_changed(int width, int height);
+
 
 VideoModeCfg vid_cfg_get_video_mode();
 


### PR DESCRIPTION
Found by running wip; each of these has a user-visible symptom.

- Deliver the quit request to the game — closing the window did nothing
- Survive SDL3's asynchronous fullscreen at startup — SDL3 defers mode changes for hidden windows, so the layout and the renderer's offscreen chain were sized from the stale pre-fullscreen window and a fullscreen boot showed only black. Size from what was requested, and re-derive the layout when the real pixel size arrives
- Do not end the process when shutting down a lost device
- Carry the level across from the back-end logger — every message was logged as information

🤖 Generated with [Claude Code](https://claude.com/claude-code)