### PR TITLE
Make audio audible on macOS

### DIFF
--- a/src/bstone/src/bstone_oal_audio_mixer.cpp
+++ b/src/bstone/src/bstone_oal_audio_mixer.cpp
@@ -1052,12 +1052,16 @@ void OalAudioMixer::initialize_oal(const AudioMixerInitParam& param)
 		}
 #endif // __APPLE__
 		if (oal_loader_ == nullptr)
+		{
 			oal_library_string = get_oal_default_library_file_name();
+		}
 	}
 	else
 		oal_library_string.append(oal_library.data(), oal_library.size());
 	if (oal_loader_ == nullptr)
+	{
 		oal_loader_ = make_oal_loader(oal_library_string.c_str());
+	}
 	log(std::string{"Using library: \""} + oal_library_string + '\"');
 	oal_loader_->load_alc_symbols();
 	detect_alc_extensions();

--- a/src/bstone/src/bstone_oal_audio_mixer.cpp
+++ b/src/bstone/src/bstone_oal_audio_mixer.cpp
@@ -1004,6 +1004,12 @@ const char* OalAudioMixer::get_oal_default_library_file_name()
 	return
 #if _WIN32
 		"OpenAL32.dll"
+#elif defined(__APPLE__)
+		// Apple ships OpenAL as a framework, and the loader only finds it by its
+		// full path: neither the bare library name nor a relative framework path
+		// resolves. Someone with a newer implementation installed can still point
+		// at it with the custom library setting.
+		"/System/Library/Frameworks/OpenAL.framework/OpenAL"
 #else
 		"libopenal.so"
 #endif // _WIN32

--- a/src/bstone/src/bstone_oal_audio_mixer.cpp
+++ b/src/bstone/src/bstone_oal_audio_mixer.cpp
@@ -1057,7 +1057,9 @@ void OalAudioMixer::initialize_oal(const AudioMixerInitParam& param)
 		}
 	}
 	else
+	{
 		oal_library_string.append(oal_library.data(), oal_library.size());
+	}
 	if (oal_loader_ == nullptr)
 	{
 		oal_loader_ = make_oal_loader(oal_library_string.c_str());

--- a/src/bstone/src/bstone_oal_audio_mixer.cpp
+++ b/src/bstone/src/bstone_oal_audio_mixer.cpp
@@ -1029,10 +1029,36 @@ void OalAudioMixer::initialize_oal(const AudioMixerInitParam& param)
 	std::string oal_library_string{};
 	const std::string_view oal_library = sd_get_oal_library();
 	if (oal_library.empty())
-		oal_library_string = get_oal_default_library_file_name();
+	{
+#if defined(__APPLE__)
+		// Apple's own framework is deprecated and renders silence for some
+		// sources on modern macOS, so an installed openal-soft gets first
+		// refusal before falling back to it.
+		static constexpr const char* candidate_library_file_names[] = {
+			"/opt/homebrew/opt/openal-soft/lib/libopenal.dylib", // Homebrew, Apple Silicon.
+			"/usr/local/opt/openal-soft/lib/libopenal.dylib", // Homebrew, Intel.
+		};
+		for (const char* candidate_library_file_name : candidate_library_file_names)
+		{
+			try
+			{
+				oal_loader_ = make_oal_loader(candidate_library_file_name);
+				oal_library_string = candidate_library_file_name;
+				break;
+			}
+			catch (...)
+			{
+			}
+		}
+#endif // __APPLE__
+		if (oal_loader_ == nullptr)
+			oal_library_string = get_oal_default_library_file_name();
+	}
 	else
 		oal_library_string.append(oal_library.data(), oal_library.size());
-	oal_loader_ = make_oal_loader(oal_library_string.c_str());
+	if (oal_loader_ == nullptr)
+		oal_loader_ = make_oal_loader(oal_library_string.c_str());
+	log(std::string{"Using library: \""} + oal_library_string + '\"');
 	oal_loader_->load_alc_symbols();
 	detect_alc_extensions();
 	log_oal_devices();

--- a/src/bstone/src/id_sd.cpp
+++ b/src/bstone/src/id_sd.cpp
@@ -492,8 +492,18 @@ void sd_startup()
 
 		if (user_driver_type == AudioDriverType::auto_detect)
 		{
+#if defined(__APPLE__)
+			// Apple's OpenAL framework initializes cleanly and reports every
+			// source as playing, yet renders silence for some of them on modern
+			// macOS, so a successful OpenAL start-up proves nothing here and
+			// auto-detection goes straight to the system mixer. OpenAL remains
+			// available by explicit choice, which prefers openal-soft when that
+			// is installed.
+			driver_types.emplace_back(AudioDriverType::system);
+#else
 			driver_types.emplace_back(AudioDriverType::openal);
 			driver_types.emplace_back(AudioDriverType::system);
+#endif
 		}
 		else
 		{


### PR DESCRIPTION
Sound effects were silent on macOS while music played.

- Load the OpenAL implementation macOS actually ships — the loader finds Apple's framework only by its full path, so the OpenAL driver never came up at all
- Keep auto-detection off Apple's silent OpenAL — the framework (deprecated since 10.15) initializes cleanly, accepts buffers and reports every source as playing, yet renders silence for some of them. Verified by rendering the same mixer through openal-soft's wave-file backend, where every sound is present in the capture. Auto-detection now goes straight to the system mixer on this platform
- Prefer openal-soft when the OpenAL driver is chosen explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)