### PR TITLE
Assorted correctness fixes

### DIFF
--- a/src/bstone/src/3d_main.cpp
+++ b/src/bstone/src/3d_main.cpp
@@ -10793,7 +10793,7 @@ void sys_sleep_for_ns(long long nanoseconds)
 
 long long sys_get_time_ns()
 {
-	return bstone::sys::get_current_time_ns();
+	return bstone::sys::get_elapsed_time_ns();
 }
 
 void sys_default_sleep_for()

--- a/src/bstone/src/3d_menu.cpp
+++ b/src/bstone/src/3d_menu.cpp
@@ -3712,12 +3712,10 @@ void ReadGameNames()
 
 		if (chunk_size > 0)
 		{
-			char temp[GAME_DESCRIPTION_LEN + 1];
-
-			std::fill_n(
-				temp,
-				GAME_DESCRIPTION_LEN,
-				'\0');
+			// The description is stored without a terminator and can occupy
+			// every one of its characters, so the extra byte has to be zeroed
+			// as well.
+			char temp[GAME_DESCRIPTION_LEN + 1]{};
 
 			auto temp_size = std::min(GAME_DESCRIPTION_LEN, chunk_size);
 

--- a/src/bstone/src/bstone_sw_video.cpp
+++ b/src/bstone/src/bstone_sw_video.cpp
@@ -730,6 +730,7 @@ try {
 
 	create_window();
 	initialize_renderer();
+	apply_window_mode();
 	initialize_textures();
 	initialize_palette();
 	initialize_vga_buffer();

--- a/src/bstone/src/bstone_sys_event_mgr_sdl.cpp
+++ b/src/bstone/src/bstone_sys_event_mgr_sdl.cpp
@@ -12,6 +12,7 @@ SPDX-License-Identifier: MIT
 #include "bstone_sys_event_mgr_null.h"
 #include "bstone_sys_logger.h"
 #include "bstone_sys_sdl_subsystem.h"
+#include <cmath>
 #include <exception>
 #include "SDL3/SDL_events.h"
 
@@ -33,6 +34,8 @@ public:
 private:
 	Logger& logger_;
 	SdlSubsystem sdl_subsystem_{};
+	float mouse_delta_x_remainder_{};
+	float mouse_delta_y_remainder_{};
 
 	static void log_sdl_error(StringBuilder& formatter);
 	static void log_keyboards(StringBuilder& formatter);
@@ -43,13 +46,14 @@ private:
 	static unsigned int map_mouse_buttons_mask(Uint32 sdl_buttons_mask);
 	static int map_mouse_button(int sdl_button);
 	static MouseWheelDirection map_mouse_wheel_direction(SDL_MouseWheelDirection sdl_direction);
+	static int take_whole_delta(float sdl_delta, float& remainder);
 
 	static bool handle_event(const SDL_KeyboardEvent& sdl_e, KeyboardEvent& e);
-	static bool handle_event(const SDL_MouseMotionEvent& sdl_e, MouseMotionEvent& e);
+	bool handle_event(const SDL_MouseMotionEvent& sdl_e, MouseMotionEvent& e);
 	static bool handle_event(const SDL_MouseButtonEvent& sdl_e, MouseButtonEvent& e);
 	static bool handle_event(const SDL_MouseWheelEvent& sdl_e, MouseWheelEvent& e);
 	static bool handle_event(const SDL_WindowEvent& sdl_e, WindowEvent& e);
-	static bool handle_event(const SDL_Event& sdl_e, Event& e);
+	bool handle_event(const SDL_Event& sdl_e, Event& e);
 };
 
 // --------------------------------------
@@ -359,6 +363,17 @@ MouseWheelDirection EventMgrSdl::map_mouse_wheel_direction(SDL_MouseWheelDirecti
 	}
 }
 
+// Relative mouse motion is reported as a floating-point amount. Truncating it
+// would throw away everything below one unit, so carry the fraction over to
+// the next event instead of losing it.
+int EventMgrSdl::take_whole_delta(float sdl_delta, float& remainder)
+{
+	const float delta = sdl_delta + remainder;
+	const float whole_delta = std::trunc(delta);
+	remainder = delta - whole_delta;
+	return static_cast<int>(whole_delta);
+}
+
 bool EventMgrSdl::handle_event(const SDL_KeyboardEvent& sdl_e, KeyboardEvent& e)
 {
 	const KeyboardKey virtual_key = map_key_code(sdl_e.key);
@@ -382,8 +397,8 @@ bool EventMgrSdl::handle_event(const SDL_MouseMotionEvent& sdl_e, MouseMotionEve
 	}
 	e.x = static_cast<int>(sdl_e.x);
 	e.y = static_cast<int>(sdl_e.y);
-	e.delta_x = static_cast<int>(sdl_e.xrel);
-	e.delta_y = static_cast<int>(sdl_e.yrel);
+	e.delta_x = take_whole_delta(sdl_e.xrel, mouse_delta_x_remainder_);
+	e.delta_y = take_whole_delta(sdl_e.yrel, mouse_delta_y_remainder_);
 	e.button_mask = map_mouse_buttons_mask(sdl_e.state);
 	e.window_id = sdl_e.windowID;
 	e.type = EventType::mouse_motion;
@@ -422,8 +437,10 @@ bool EventMgrSdl::handle_event(const SDL_MouseWheelEvent& sdl_e, MouseWheelEvent
 	{
 		return false;
 	}
-	e.x = static_cast<int>(sdl_e.x);
-	e.y = static_cast<int>(sdl_e.y);
+	// The floating-point amounts lose everything below one tick when truncated,
+	// which on a trackpad or a high-resolution wheel is every single event.
+	e.x = sdl_e.integer_x;
+	e.y = sdl_e.integer_y;
 	e.direction = direction;
 	e.window_id = sdl_e.windowID;
 	e.type = EventType::mouse_wheel;

--- a/src/bstone/src/bstone_sys_gl_context_sdl.cpp
+++ b/src/bstone/src/bstone_sys_gl_context_sdl.cpp
@@ -8,6 +8,7 @@ SPDX-License-Identifier: MIT
 
 #include "bstone_exception.h"
 #include "bstone_scope_exit.h"
+#include "bstone_sdl.h"
 #include "bstone_sys_gl_context_sdl.h"
 #include <format>
 #include <string>
@@ -42,6 +43,10 @@ private:
 GlContextSdl::GlContextSdl(SDL_Window& sdl_window)
 {
 	SDL_GLContext sdl_gl_context = SDL_GL_CreateContext(&sdl_window);
+	if (sdl_gl_context == nullptr)
+	{
+		sdl::fail("SDL_GL_CreateContext");
+	}
 	const auto scope_exit = make_scope_exit(
 		[&sdl_gl_context]()
 		{

--- a/src/bstone/src/bstone_sys_message_box.h
+++ b/src/bstone/src/bstone_sys_message_box.h
@@ -57,6 +57,9 @@ struct MessageBoxInitParam
 struct MessageBox
 {
 	static void show_simple(const char* title, const char* message, MessageBoxType type);
+
+	// Returns the id of the clicked button or a negative value if the message
+	// box was dismissed without clicking one.
 	static int show(const MessageBoxInitParam& param);
 };
 

--- a/src/bstone/src/bstone_sys_message_box_sdl.cpp
+++ b/src/bstone/src/bstone_sys_message_box_sdl.cpp
@@ -86,7 +86,9 @@ int MessageBox::show(const MessageBoxInitParam& param)
 		.buttons = sdl_buttons,
 		.colorScheme = nullptr,
 	};
-	int sdl_button_id = 0;
+	// Not every backend reports a dismissed dialog, so start out with the same
+	// value the ones that do report use.
+	int sdl_button_id = -1;
 	if (!SDL_ShowMessageBox(&sdl_message_box, &sdl_button_id))
 	{
 		sdl::fail("SDL_ShowMessageBox");

--- a/src/bstone/src/bstone_sys_texture_lock_sdl.cpp
+++ b/src/bstone/src/bstone_sys_texture_lock_sdl.cpp
@@ -62,7 +62,10 @@ public:
 private:
 	static constexpr std::size_t storage_size = sizeof(TextureLockSdl);
 	bool is_allocated_{};
-	std::byte storage_[storage_size];
+
+	// The buffer stands in for the default allocator, so it has to be aligned
+	// for the object it holds and not for the byte it is made of.
+	alignas(TextureLockSdl) std::byte storage_[storage_size];
 };
 
 // ======================================

--- a/src/bstone/src/bstone_sys_time.h
+++ b/src/bstone/src/bstone_sys_time.h
@@ -11,7 +11,7 @@ SPDX-License-Identifier: MIT
 
 namespace bstone::sys {
 
-// The number of non-leap nanoseconds that have elapsed since 00:00:00 UTC on 1 January 1970.
+// A number of nanoseconds.
 using TimeNs = long long;
 
 enum DateTimeKind
@@ -34,7 +34,14 @@ struct DateTime
 	int utc_offset_s; // UTC offset in seconds.
 };
 
+// The number of non-leap nanoseconds that have elapsed since 00:00:00 UTC on 1 January 1970.
+// The system clock can be stepped at any moment, so do not measure durations with it.
 TimeNs get_current_time_ns();
+
+// The number of nanoseconds that have elapsed since an unspecified moment in the past.
+// Never goes backwards, hence the source to measure durations with.
+TimeNs get_elapsed_time_ns();
+
 DateTime time_ns_to_date_time(TimeNs time_ns, DateTimeKind date_time_kind);
 
 } // namespace bstone::sys

--- a/src/bstone/src/bstone_sys_time_sdl.cpp
+++ b/src/bstone/src/bstone_sys_time_sdl.cpp
@@ -10,6 +10,7 @@ SPDX-License-Identifier: MIT
 #include "bstone_exception.h"
 #include "bstone_sdl.h"
 #include <cstddef>
+#include "SDL3/SDL_timer.h"
 #include "SDL3/SDL_time.h"
 
 namespace bstone::sys {
@@ -22,6 +23,11 @@ TimeNs get_current_time_ns()
 		sdl::fail("SDL_GetCurrentTime");
 	}
 	return sdl_time;
+}
+
+TimeNs get_elapsed_time_ns()
+{
+	return static_cast<TimeNs>(SDL_GetTicksNS());
 }
 
 DateTime time_ns_to_date_time(TimeNs time_ns, DateTimeKind date_time_kind)

--- a/src/bstone/src/bstone_vfs.cpp
+++ b/src/bstone/src/bstone_vfs.cpp
@@ -18,6 +18,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <cstdint>
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <ranges>
 #include <string>
 #include <string_view>
@@ -185,6 +186,8 @@ struct VfsSearchPathImpl : VfsSearchPath
 	VfsSearchPathImplArchiveLookup impl_archive_lookup;
 };
 
+using VfsSearchPathImplUPtr = std::unique_ptr<VfsSearchPathImpl>;
+
 struct VfsFindArchivesContext
 {
 	const std::string_view archive_extension;
@@ -228,7 +231,9 @@ private:
 	inline constinit static const std::string_view log_prefix = "VFS";
 	inline constinit static const std::string_view zip_extenstion = ".bstone_zip";
 
-	using SearchPaths = std::vector<VfsSearchPathImpl>;
+	// Every search path hands out a pointer into its own pathname, so the
+	// entries have to keep their addresses as the list grows.
+	using SearchPaths = std::vector<VfsSearchPathImplUPtr>;
 
 	bool is_open_{};
 	Logger* logger_{};
@@ -281,7 +286,7 @@ int VfsImpl::get_search_path_count()
 const VfsSearchPath& VfsImpl::get_search_path(int index)
 {
 	BSTONE_ASSERT(index >= 0 && index < get_search_path_count());
-	return search_paths_[index];
+	return *search_paths_[index];
 }
 
 VfsInputStreamUPtr VfsImpl::open_file(std::string_view vfs_pathname)
@@ -300,7 +305,7 @@ VfsInputStreamUPtr VfsImpl::open_any_file(std::span<std::string_view> vfs_pathna
 {
 	for (const auto& search_path : std::views::reverse(search_paths_))
 	{
-		if (VfsInputStreamUPtr stream = open_any_file(search_path, vfs_pathnames);
+		if (VfsInputStreamUPtr stream = open_any_file(*search_path, vfs_pathnames);
 			stream != nullptr)
 			return stream;
 	}
@@ -414,7 +419,7 @@ void VfsImpl::add_search_path_archive(const std::string& pathname)
 		return;
 	}
 	logger_->log_information("[{}] Found {} compatible entries.", log_prefix, archive_lookup.size());
-	VfsSearchPathImpl& search_path = search_paths_.emplace_back();
+	VfsSearchPathImpl& search_path = *search_paths_.emplace_back(std::make_unique<VfsSearchPathImpl>());
 	search_path.impl_path = pathname;
 	search_path.impl_archive.swap(archive);
 	search_path.impl_archive_lookup.swap(archive_lookup);
@@ -456,7 +461,7 @@ void VfsImpl::add_search_path_directory(const std::string& pathname)
 		logger_->log_error("[{}] Unknown file type.", log_prefix);
 		return;
 	}
-	VfsSearchPathImpl& search_path = search_paths_.emplace_back();
+	VfsSearchPathImpl& search_path = *search_paths_.emplace_back(std::make_unique<VfsSearchPathImpl>());
 	search_path.impl_path = pathname;
 	search_path.type = VfsSearchPathType::directory;
 	search_path.path = search_path.impl_path.data();

--- a/src/bstone/src/bstone_vfs.cpp
+++ b/src/bstone/src/bstone_vfs.cpp
@@ -307,7 +307,9 @@ VfsInputStreamUPtr VfsImpl::open_any_file(std::span<std::string_view> vfs_pathna
 	{
 		if (VfsInputStreamUPtr stream = open_any_file(*search_path, vfs_pathnames);
 			stream != nullptr)
+		{
 			return stream;
+		}
 	}
 	return nullptr;
 }

--- a/src/bstone/src/bstone_vfs.cpp
+++ b/src/bstone/src/bstone_vfs.cpp
@@ -332,6 +332,7 @@ void VfsImpl::impl_terminate()
 {
 	is_open_ = false;
 	logger_ = nullptr;
+	search_paths_.clear();
 }
 
 bool VfsImpl::impl_initialize(const VfsInitParam& param)
@@ -340,6 +341,7 @@ bool VfsImpl::impl_initialize(const VfsInitParam& param)
 	logger_ = param.logger;
 	logger_->log_information("[{}] Initialize.", log_prefix);
 	add_search_paths(param);
+	is_open_ = true;
 	return true;
 }
 

--- a/src/bstone/src/bstone_vswap.cpp
+++ b/src/bstone/src/bstone_vswap.cpp
@@ -51,6 +51,7 @@ private:
 	static constexpr int max_file_size = 4'000'000;
 	static constexpr int min_chunks = 0;
 	static constexpr int max_chunks = 1400;
+	static constexpr int wall_page_size = 64 * 64;
 
 	struct BytesDeleter
 	{
@@ -114,6 +115,12 @@ VswapImpl::VswapImpl()
 		if (chunk_offset < data_start || chunk_offset > file_size || chunk_offset + chunk_size > file_size)
 		{
 			BSTONE_THROW_STATIC_SOURCE("Invalid chunk boundaries.");
+		}
+		// Every consumer of a wall reads a whole page without consulting the
+		// declared size, so a short one would be read past its end.
+		if (i < sprite_start && chunk_size != wall_page_size)
+		{
+			BSTONE_THROW_STATIC_SOURCE("Invalid wall size.");
 		}
 	}
 }

--- a/src/bstone/src/bstone_win32_wstring.h
+++ b/src/bstone/src/bstone_win32_wstring.h
@@ -37,7 +37,6 @@ public:
 		const int u16_size_with_null = utf8_to_utf16(u8_string, u8_size_with_null);
 		if (u16_size_with_null < 0)
 		{
-			storage_ = nullptr;
 			return;
 		}
 		if (u16_size_with_null <= TStackCapacity)

--- a/src/bstone/src/bstone_win32_wstring.h
+++ b/src/bstone/src/bstone_win32_wstring.h
@@ -37,6 +37,7 @@ public:
 		const int u16_size_with_null = utf8_to_utf16(u8_string, u8_size_with_null);
 		if (u16_size_with_null < 0)
 		{
+			storage_ = nullptr;
 			return;
 		}
 		if (u16_size_with_null <= TStackCapacity)
@@ -90,7 +91,7 @@ public:
 
 private:
 	wchar_t stack_storage_[TStackCapacity];
-	wchar_t* storage_;
+	wchar_t* storage_{};
 	int size_{};
 
 	void deallocate()

--- a/src/bstone/src/bstone_zip_archive_file.cpp
+++ b/src/bstone/src/bstone_zip_archive_file.cpp
@@ -278,7 +278,9 @@ void ZipArchiveFile::deserialize_local_file_header(MemoryBinaryReader& binary_re
 bool ZipArchiveFile::validate_local_file_header(const LocalFileHeader& header, const ArchiveFileEntry& entry)
 {
 	if (header.signature != 0x04034B50U)
+	{
 		return false;
+	}
 	if (((header.flags & file_encrypted_flag) != 0) ||
 		((header.flags & patched_data_flag) != 0) ||
 		((header.flags & strong_encryption_flag) != 0) ||
@@ -290,7 +292,9 @@ bool ZipArchiveFile::validate_local_file_header(const LocalFileHeader& header, c
 	const ArchiveFileLanguageEncoding language_encoding =
 		is_utf8 ? ArchiveFileLanguageEncoding::utf8 : ArchiveFileLanguageEncoding::cp437;
 	if (language_encoding != entry.language_encoding)
+	{
 		return false;
+	}
 	ArchiveFileCompressionMethod compression_method;
 	switch (header.compression_method)
 	{
@@ -305,19 +309,29 @@ bool ZipArchiveFile::validate_local_file_header(const LocalFileHeader& header, c
 			break;
 	}
 	if (compression_method != entry.compression_method)
+	{
 		return false;
+	}
 	const bool has_data_descriptor = (header.flags & data_descriptor_flag) != 0;
 	if (!has_data_descriptor)
 	{
 		if (header.crc_32 != entry.crc_32)
+		{
 			return false;
+		}
 		if (header.compressed_size != static_cast<unsigned int>(entry.compressed_size))
+		{
 			return false;
+		}
 		if (header.uncompressed_size != static_cast<unsigned int>(entry.uncompressed_size))
+		{
 			return false;
+		}
 	}
 	if (header.file_name_length != entry.name_length)
+	{
 		return false;
+	}
 	return true;
 }
 
@@ -354,19 +368,33 @@ bool ZipArchiveFile::validate_end_of_central_dir_record(const EndOfCentralDirRec
 	// A ZIP64 archive, a multi-disk one and a self-contradicting one are all simply
 	// unsupported input, so they are refused the same way an unreadable file would be.
 	if (record.this_disk_number != 0)
+	{
 		return false;
+	}
 	if (record.dir_disk_number != 0)
+	{
 		return false;
+	}
 	if (record.this_total_entries == zip64_marker_16)
+	{
 		return false;
+	}
 	if (record.dir_total_entries == zip64_marker_16)
+	{
 		return false;
+	}
 	if (record.this_total_entries != record.dir_total_entries)
+	{
 		return false;
+	}
 	if (record.dir_size == zip64_marker_32)
+	{
 		return false;
+	}
 	if (record.dir_size > max_central_dir_size)
+	{
 		return false;
+	}
 	// The entry name arena is sized by subtracting the fixed part of every promised header
 	// from the directory size. Nothing else ties the two fields together, so a directory
 	// too small to hold the entries it promises would undersize the arena.
@@ -375,7 +403,9 @@ bool ZipArchiveFile::validate_end_of_central_dir_record(const EndOfCentralDirRec
 		return false;
 	}
 	if (record.dir_offset == zip64_marker_32)
+	{
 		return false;
+	}
 	return true;
 }
 
@@ -383,9 +413,13 @@ bool ZipArchiveFile::read_end_of_central_dir_record(EndOfCentralDirRecord& recor
 {
 	const long long archive_size = input_stream_->get_size();
 	if (archive_size < 0)
+	{
 		return false;
+	}
 	if (archive_size < end_of_central_dir_record_size)
+	{
 		return false;
+	}
 	constexpr int max_comment_length = 0xFFFF;
 	constexpr int history_size = end_of_central_dir_record_size - 1;
 	constexpr long long max_scan_size = end_of_central_dir_record_size + max_comment_length;
@@ -433,7 +467,9 @@ bool ZipArchiveFile::read_end_of_central_dir_record(EndOfCentralDirRecord& recor
 bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_reader, CentralFileHeader& header)
 {
 	if (!binary_reader.can_read_n(central_file_header_size))
+	{
 		return false;
+	}
 	// central file header signature   4 bytes  (0x02014B50)
 	header.signature                = binary_reader.read_u32_le();
 	// version made by                 2 bytes
@@ -470,12 +506,16 @@ bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_
 	header.local_header_offset      = binary_reader.read_u32_le();
 	// file name (variable size)
 	if (!binary_reader.can_read_n(header.file_name_length))
+	{
 		return false;
+	}
 	header.file_name = static_cast<const char*>(binary_reader.get_current_data());
 	binary_reader.skip(header.file_name_length);
 	// extra field (variable size)
 	if (!binary_reader.can_read_n(header.extra_field_length))
+	{
 		return false;
+	}
 	// Look up for language-related extra fields.
 	header.has_extended_language_encoding_data = false;
 	header.has_info_zip_unicode_path_extra_field = false;
@@ -509,7 +549,9 @@ bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_
 	}
 	// file comment (variable size)
 	if (!binary_reader.can_read_n(header.file_comment_length))
+	{
 		return false;
+	}
 	binary_reader.skip(header.file_comment_length);
 	//
 	return true;
@@ -518,9 +560,13 @@ bool ZipArchiveFile::deserialize_central_file_header(MemoryBinaryReader& binary_
 bool ZipArchiveFile::validate_central_file_header(const CentralFileHeader& header) const
 {
 	if (header.signature != 0x02014B50U)
+	{
 		return false;
+	}
 	if (header.disk_number_start != 0)
+	{
 		return false;
+	}
 	return true;
 }
 
@@ -667,10 +713,14 @@ bool ZipArchiveFile::read_central_dir(const EndOfCentralDirRecord& eocdr)
 	BufferUPtr dir_buffer{::operator new(std::size_t{eocdr.dir_size})};
 	reserve_entries(eocdr.dir_total_entries);
 	if (!input_stream_->set_position(eocdr.dir_offset))
+	{
 		return false;
+	}
 	MemoryBinaryReader dir_binary_reader{dir_buffer.get(), static_cast<int>(eocdr.dir_size)};
 	if (!input_stream_->read_exactly(dir_buffer.get(), static_cast<int>(eocdr.dir_size)))
+	{
 		return false;
+	}
 	const int names_capacity = static_cast<int>(eocdr.dir_size) -
 		((central_file_header_size - 16 /* (alignment-1)+NULL */) * eocdr.dir_total_entries);
 	reserve_names(names_capacity);

--- a/src/bstone/src/jm_lzh.cpp
+++ b/src/bstone/src/jm_lzh.cpp
@@ -899,7 +899,9 @@ try {
 
 			const std::int16_t j = c - 255 + THRESHOLD;
 
-			for (std::int16_t k = 0; k < j; ++k)
+			// A match emits up to F bytes at once, so the outer bound is not
+			// enough to keep the last token inside the caller's buffer.
+			for (std::int16_t k = 0; k < j && count < textsize; ++k)
 			{
 				c = text_buf[(i + k) & (N - 1)];
 

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -132,6 +132,8 @@ target_sources(bstone_tests
 		../../../bstone/src/bstone_opl_music_decoder.cpp
 		../../../bstone/src/bstone_opl_music_decoder.h
 		../../../bstone/src/bstone_r3r.h
+		../../../bstone/src/jm_lzh.cpp
+		../../../bstone/src/jm_lzh.h
 	PRIVATE
 		src/bstone_tests_ascii.cpp
 		src/bstone_tests_char_conv.cpp
@@ -161,7 +163,11 @@ target_sources(bstone_tests
 		src/bstone_tests_opl_sfx_decoder.cpp
 		src/bstone_tests_opl_music_decoder.cpp
 		src/bstone_tests_r3r.cpp
+<<<<<<< HEAD
 		src/bstone_tests_r3r_sample_count.cpp
+=======
+		src/bstone_tests_jm_lzh.cpp
+>>>>>>> fda5696d ([LZH] Stop the decoder writing past the end of the output buffer)
 	PRIVATE
 		src/bstone_tester.cpp
 		src/bstone_tester.h

--- a/src/tests/src/tests/CMakeLists.txt
+++ b/src/tests/src/tests/CMakeLists.txt
@@ -163,11 +163,8 @@ target_sources(bstone_tests
 		src/bstone_tests_opl_sfx_decoder.cpp
 		src/bstone_tests_opl_music_decoder.cpp
 		src/bstone_tests_r3r.cpp
-<<<<<<< HEAD
 		src/bstone_tests_r3r_sample_count.cpp
-=======
 		src/bstone_tests_jm_lzh.cpp
->>>>>>> fda5696d ([LZH] Stop the decoder writing past the end of the output buffer)
 	PRIVATE
 		src/bstone_tester.cpp
 		src/bstone_tester.h

--- a/src/tests/src/tests/src/bstone_tests_jm_lzh.cpp
+++ b/src/tests/src/tests/src/bstone_tests_jm_lzh.cpp
@@ -1,0 +1,121 @@
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "bstone_tester.h"
+#include "jm_lzh.h"
+
+namespace {
+
+auto tester = bstone::Tester{};
+
+// ==========================================================================
+
+using Bytes = std::vector<std::uint8_t>;
+
+Bytes compress(const Bytes& decompressed)
+{
+	auto compressed = Bytes{};
+	compressed.resize((4 * decompressed.size()) + 1024);
+	const auto compressed_size = LZH_Compress(
+		decompressed.data(),
+		compressed.data(),
+		static_cast<int>(decompressed.size()));
+	compressed.resize(static_cast<std::size_t>(compressed_size));
+	return compressed;
+}
+
+// ==========================================================================
+
+// int LZH_Decompress(const std::uint8_t*, std::uint8_t*, int, int)
+// Round trip.
+void test_kkgkq1zjcmmzcgc5()
+{
+	auto decompressed = Bytes{};
+	decompressed.resize(1000);
+
+	for (auto i = std::size_t{}; i < decompressed.size(); ++i)
+	{
+		decompressed[i] = static_cast<std::uint8_t>((i / 10) + (i % 7));
+	}
+
+	const auto compressed = compress(decompressed);
+
+	auto result = Bytes{};
+	result.resize(decompressed.size());
+
+	const auto result_size = LZH_Decompress(
+		compressed.data(),
+		result.data(),
+		static_cast<int>(result.size()),
+		static_cast<int>(compressed.size()));
+
+	tester.check(
+		result_size == static_cast<int>(decompressed.size()) &&
+		result == decompressed);
+}
+
+// int LZH_Decompress(const std::uint8_t*, std::uint8_t*, int, int)
+// Writes no more than the requested number of bytes.
+void test_p4rzvt4x38fmn9pe()
+{
+	constexpr auto guard_size = std::size_t{64};
+	constexpr auto guard_value = std::uint8_t{0xCD};
+	constexpr auto data_value = std::uint8_t{'A'};
+
+	// A long run of the same byte compresses into maximum length matches, so
+	// most of the requested sizes below end up in the middle of a match.
+	auto decompressed = Bytes{};
+	decompressed.resize(256, data_value);
+
+	const auto compressed = compress(decompressed);
+
+	auto is_succeed = true;
+	auto result = Bytes{};
+
+	for (auto size = std::size_t{1}; size <= decompressed.size(); ++size)
+	{
+		result.clear();
+		result.resize(size + guard_size, guard_value);
+
+		const auto result_size = LZH_Decompress(
+			compressed.data(),
+			result.data(),
+			static_cast<int>(size),
+			static_cast<int>(compressed.size()));
+
+		is_succeed &= result_size == static_cast<int>(size);
+		is_succeed &= std::all_of(
+			result.cbegin(),
+			result.cbegin() + static_cast<std::ptrdiff_t>(size),
+			[](std::uint8_t value) { return value == data_value; });
+		is_succeed &= std::all_of(
+			result.cbegin() + static_cast<std::ptrdiff_t>(size),
+			result.cend(),
+			[](std::uint8_t value) { return value == guard_value; });
+	}
+
+	tester.check(is_succeed);
+}
+
+// ==========================================================================
+
+class Registrator
+{
+public:
+	Registrator()
+	{
+		register_lzh_decompress();
+	}
+
+private:
+	void register_lzh_decompress()
+	{
+		tester.register_test("LZH_Decompress#kkgkq1zjcmmzcgc5", test_kkgkq1zjcmmzcgc5);
+		tester.register_test("LZH_Decompress#p4rzvt4x38fmn9pe", test_p4rzvt4x38fmn9pe);
+	}
+};
+
+auto registrator = Registrator{};
+
+} // namespace


### PR DESCRIPTION
From a correctness review of wip; twelve small independent fixes.

- Require a VSWAP wall chunk to hold a whole page
- Report a failed Win32 string conversion with a null pointer
- Terminate a full-length saved game description
- Start the software renderer in the configured window mode
- Fail when a GL context cannot be created
- Honour the VFS initialize/terminate lifecycle
- Keep the VFS search path entries at a fixed address
- Align the texture lock storage for the object it holds
- Keep sub-unit mouse wheel and motion amounts
- Measure elapsed time with a monotonic clock
- Treat a dismissed product dialog as a cancellation
- Stop the LZH decoder writing past the end of the output buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)