### PR TITLE
Find GOG installations on macOS

### DIFF
--- a/src/bstone/CMakeLists.txt
+++ b/src/bstone/CMakeLists.txt
@@ -281,6 +281,7 @@ endif ()
 
 target_link_libraries(bstone
 	PRIVATE
+		$<$<BOOL:${APPLE}>:sqlite3>
 		$<$<AND:$<BOOL:${WIN32}>,$<BOOL:${MINGW}>>:-municode>
 		${CMAKE_DL_LIBS}
 		bstone::lib::sdl

--- a/src/bstone/src/bstone_gog_content_path.cpp
+++ b/src/bstone/src/bstone_gog_content_path.cpp
@@ -17,9 +17,153 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include "bstone_win32_registry_key.h"
 #endif // _WIN32
 
+#ifdef __APPLE__
+#include <string>
+
+#include <sqlite3.h>
+
+#include "bstone_fs_utils.h"
+#include "bstone_sys_file.h"
+#endif // __APPLE__
+
 
 namespace bstone
 {
+
+#ifdef __APPLE__
+namespace
+{
+
+struct GogMacProduct
+{
+	long long product_id;
+	// The outer bundle's name drifted between releases; the id file inside
+	// stays put and carries the product id the Windows registry uses.
+	const char* bundle_names[2];
+	const char* id_file_name;
+	const char* game_name;
+	const char* marker_file_name;
+};
+
+constexpr GogMacProduct gog_mac_products[2] =
+{
+	GogMacProduct{
+		1207658728,
+		{"Blake Stone - Aliens of Gold.app", "Blake Stone Aliens of Gold.app"},
+		".goggame-1207658728.info",
+		"Blake Stone Aliens of Gold",
+		"AUDIOHED.BS6"},
+	GogMacProduct{
+		1207658729,
+		{"Blake Stone Planet Strike.app", "Blake Stone - Planet Strike.app"},
+		".goggame-1207658729.info",
+		"Blake Stone Planet Strike",
+		"AUDIOHED.VSI"},
+};
+
+// The client keeps the machine-wide install registry here, the way the
+// Windows client keeps it under HKLM.
+constexpr const char* galaxy_db_path = "/Users/Shared/GOG.com/Galaxy/Storage/galaxy-2.0.db";
+
+std::string get_galaxy_installation_path(long long product_id)
+{
+	std::string path{};
+	sqlite3* db = nullptr;
+
+	if (sqlite3_open_v2(galaxy_db_path, &db, SQLITE_OPEN_READONLY, nullptr) == SQLITE_OK)
+	{
+		sqlite3_stmt* statement = nullptr;
+
+		if (sqlite3_prepare_v2(
+			db,
+			"SELECT installationPath FROM InstalledBaseProducts WHERE productId = ?;",
+			-1,
+			&statement,
+			nullptr) == SQLITE_OK)
+		{
+			sqlite3_bind_int64(statement, 1, product_id);
+
+			if (sqlite3_step(statement) == SQLITE_ROW)
+			{
+				const unsigned char* text = sqlite3_column_text(statement, 0);
+
+				if (text != nullptr)
+				{
+					path = reinterpret_cast<const char*>(text);
+				}
+			}
+
+			sqlite3_finalize(statement);
+		}
+
+		sqlite3_close(db);
+	}
+
+	return path;
+}
+
+bool file_exists(const std::string& path)
+{
+	auto file = sys::File{};
+	return file.open(path.c_str(), sys::FileMode::read);
+}
+
+// The bundle is a launcher app wrapping a Boxer app whose gamebox holds
+// the DOS drive with the game's files.
+std::string find_data_in_gog_mac_bundle(const std::string& bundle_path, const GogMacProduct& product)
+{
+	const std::string name = product.game_name;
+	const std::string data_path = fs_utils::append_path(
+		bundle_path,
+		"Contents/Resources/game/" + name + ".app/Contents/Resources/" + name + ".boxer/C " + name + ".harddisk");
+
+	if (file_exists(fs_utils::append_path(data_path, product.marker_file_name)))
+	{
+		return data_path;
+	}
+
+	return std::string{};
+}
+
+std::string find_gog_mac_game_path(const GogMacProduct& product)
+{
+	// The Galaxy client records where it installed the product.
+	const std::string galaxy_bundle_path = get_galaxy_installation_path(product.product_id);
+
+	if (!galaxy_bundle_path.empty())
+	{
+		const std::string data_path = find_data_in_gog_mac_bundle(galaxy_bundle_path, product);
+
+		if (!data_path.empty())
+		{
+			return data_path;
+		}
+	}
+
+	// Without the client - the offline installer - the bundle sits in
+	// "/Applications", identified by the id file its installer drops.
+	for (const char* bundle_name : product.bundle_names)
+	{
+		const std::string bundle_path = fs_utils::append_path("/Applications", bundle_name);
+
+		if (!file_exists(fs_utils::append_path(bundle_path, fs_utils::append_path("Contents/Resources", product.id_file_name))))
+		{
+			continue;
+		}
+
+		const std::string data_path = find_data_in_gog_mac_bundle(bundle_path, product);
+
+		if (!data_path.empty())
+		{
+			return data_path;
+		}
+	}
+
+	return std::string{};
+}
+
+} // namespace
+#endif // __APPLE__
 
 
 AssetPath make_gog_content_path()
@@ -107,6 +251,11 @@ AssetPath make_gog_content_path()
 		}
 	}
 #endif // _WIN32
+
+#ifdef __APPLE__
+	result.aog = find_gog_mac_game_path(gog_mac_products[0]);
+	result.ps = find_gog_mac_game_path(gog_mac_products[1]);
+#endif // __APPLE__
 
 	return result;
 }


### PR DESCRIPTION
GOG discovery read the Windows uninstall registry and nothing else, so on macOS it returned an empty result and GOG owners had to pass --data_dir by hand.

The Galaxy client keeps a machine-wide install registry the way the Windows client keeps one under HKLM: an SQLite database at /Users/Shared/GOG.com/Galaxy/Storage/galaxy-2.0.db whose InstalledBaseProducts table maps the same product ids the Windows registry uses to the installation path. That answers a custom install location too. sqlite3 is a system library on macOS, so reading it adds no dependency.

Without the client — the offline installer — the bundle sits in /Applications, identified by the hidden .goggame-<id>.info file its installer drops; the bundle name itself has drifted between releases ("Blake Stone - Aliens of Gold" with a dash, "Blake Stone Planet Strike" without), so the id file is what gets trusted.

Either way the data sits at the bottom of a double bundle — a launcher app wrapping a Boxer app whose gamebox holds the DOS drive:

```
<bundle>/Contents/Resources/game/<name>.app/Contents/Resources/<name>.boxer/C <name>.harddisk/
```

A candidate is only accepted if it holds an asset the game cannot run without (AUDIOHED.BS6 / AUDIOHED.VSI), matching how the Steam discovery in #563 probes.

Verified against real Galaxy installations of both games on macOS: discovery resolves both without --data_dir, and the found Aliens of Gold is v2.1 (GOG ships a newer revision than the Steam depot's v1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)